### PR TITLE
changed the defang up to defang compose up on docs

### DIFF
--- a/docs/concepts/compose.md
+++ b/docs/concepts/compose.md
@@ -12,7 +12,7 @@ You might be familiar with `docker-compose.yml` files, now known as the [Compose
 
 You can define your [services](./services.md) using a `compose.yaml` file in the root of your project, or use the [`defang generate` command](../tutorials/generate-new-code-using-ai.mdx) to generate one (along with other resources). This file is used to define your application's services and how they run. You can edit this file to add more services or change the configuration of existing services.
 
-When you run `defang up`, Defang will read your `compose.yaml` file and [deploy](./deployments.md) the services named in that file to the cloud.
+When you run `defang compose up`, Defang will read your `compose.yaml` file and [deploy](./deployments.md) the services named in that file to the cloud.
 
 ## Service Name Resolution
 

--- a/docs/concepts/observability.md
+++ b/docs/concepts/observability.md
@@ -1,14 +1,14 @@
 ---
-title: Observability    
+title: Observability
 description: Monitor and debug your Defang services with the Defang CLI and portal.
 sidebar_position: 600
 ---
 
 # Observability
 
-You can easily monitor and debug your Defang services at build and runtime using the Defang CLI and portal. 
+You can easily monitor and debug your Defang services at build and runtime using the Defang CLI and portal.
 
-When you deploy a service using the `defang up` the CLI will automatically start tailing the build and runtime logs for your service. You can also view the logs for your service in the portal, or by using the `defang tail` command.
+When you deploy a service using the `defang compose up` the CLI will automatically start tailing the build and runtime logs for your service. You can also view the logs for your service in the portal, or by using the `defang tail` command.
 
 :::warning
 Keep in mind that the Defang Portal only displays services deployed to Defang Playground.


### PR DESCRIPTION
This PR is an attempt to update some out of date information. I have a few questions here that also need answered because they might be outdated. 

1. Defang BYOC, do you want to mention digital ocean here?  (https://docs.defang.io/docs/concepts/defang-byoc)
2. Under accounts structure, does sharding, i.e. 1a matter? (<username>-<servicename>--<port>.prod1.defang.dev) does sharding matter? 
3. Do you want to mention one click deployments?
4. Under Compose, are we still using secrets? (https://docs.defang.io/docs/concepts/compose#configuration) still mentions secrets which I am unsure if that is still in use