### PR TITLE
Notify slack if deploy action fails

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -92,4 +92,12 @@ jobs:
           user_email: 41898282+github-actions[bot]@users.noreply.github.com
           cname: docs.defang.io
 
-
+      - name: Notify Slack of Action Failures
+        uses: ravsamhq/notify-slack-action@2.5.0
+        if: ${{ always() && github.ref_name == 'main' }}
+        with:
+          status: ${{ job.status }}
+          notify_when: "failure"
+          notification_title: "{workflow} is failing"
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_NOTIFIER_WEBHOOK_URL }}


### PR DESCRIPTION
Yesterday a triggered workflow [failed](https://github.com/DefangLabs/defang-docs/actions/runs/10292749621), and we didn't realize it right away. The workflow is intended to automatically update our docs after we released a build of the defang cli.

This PR adds a workflow step to notify a slack channel when it fails.

The `SLACK_NOTIFIER_WEBHOOK_URL` secret has been added here:
https://github.com/DefangLabs/defang-docs/settings/secrets/actions