### PR TITLE
Avoid redirecting to production in development

### DIFF
--- a/static/index.html
+++ b/static/index.html
@@ -4,15 +4,15 @@
     <meta charset="UTF-8" />
     <meta
       http-equiv="refresh"
-      content="0; url=https://docs.defang.io/docs"
+      content="0; url=/docs"
     />
     <script type="text/javascript">
-      window.location.href = 'https://docs.defang.io/docs';
+      window.location.href = '/docs';
     </script>
     <title>Defang Docs</title>
   </head>
   <body>
     If you are not redirected automatically, follow this
-    <a href="https://docs.defang.io/docs">link</a>.
+    <a href="/docs">link</a>.
   </body>
 </html>


### PR DESCRIPTION
Not sure why this was done, but it's very disorienting when you start a development server (because your browser automatically opens `http://localhost:3000/`). It took me longer than I would like to admit before I realized that I was looking at `https://docs.defang.io/docs`.