### PR TITLE
fixed dark mode text on samples docs page

### DIFF
--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -78,3 +78,10 @@
 a.MuiButtonBase-root:hover {
   color: white !important;
 }
+
+/* Tentative change to address dark mode text on Samples page.
+To go further, consider looking at implementing MUI custom themes. 
+*/
+.MuiTypography-root, .MuiFormLabel-root, .MuiInputBase-input {
+  color: var(--ifm-font-color-base) !important;
+}


### PR DESCRIPTION
Added a fix so text is white on dark mode for both the search bar and samples content in the Samples page.