### PR TITLE
Document BYOC

### DIFF
--- a/docs/concepts/_category_.json
+++ b/docs/concepts/_category_.json
@@ -1,9 +1,8 @@
 {
   "label": "Concepts",
-  "position": 300,
+  "position": 500,
   "link": {
     "type": "generated-index",
     "description": "Some concepts to help explain how the Defang system is organized and tooling that will help you manage your applications."
   }
 }
-

--- a/docs/concepts/debug.md
+++ b/docs/concepts/debug.md
@@ -6,10 +6,10 @@ sidebar_position: 650
 
 # Debug
 
-Defang includes an AI-driven tool to help you debug your cloud applications. The AI assistant will use your service logs as well as the files in your project to help you identify and resolve issues.
+Defang includes an AI-driven tool to help you debug your cloud applications. The AI agent will use your service logs as well as the files in your project to help you identify and resolve issues.
 
 :::warning
-The AI debugging assistant is currently in preview and is currently limited in its capabilities. We plan to expand the capabilities of the AI assistant in the future.
+The AI debugging agent is currently in preview and is currently limited in its capabilities. We plan to expand the capabilities of the AI agent in the future.
 :::
 
 ## How it works

--- a/docs/concepts/defang-playground.md
+++ b/docs/concepts/defang-playground.md
@@ -27,5 +27,5 @@ When you deploy a service to Defang Playground, it will be assigned a domain und
 * Projects: 1
 * Services: 4
 * CPUs: 2
-* Memory: 8GB
-* Replicas: 2
+* Memory: 1GiB
+* Replicas: 1

--- a/docs/concepts/deployment-modes.md
+++ b/docs/concepts/deployment-modes.md
@@ -1,0 +1,26 @@
+---
+title: Defang Deployment Modes
+description: Defang provides three deployment modes which allow you to balance cost and resiliency.
+sidebar_position: 501
+---
+
+# Defang Deployment Modes
+
+Defang provides three deployment modes: development, staging, and production. These modes allow you to balance cost and resiliency according to your needs.
+
+* **Development**: This mode is used for development and testing purposes. It typically involves less stringent resource allocations and may include debugging tools and verbose logging to aid in development.
+* **Staging**: This mode serves as a pre-production environment where applications are tested in conditions that closely mimic production. It helps in identifying issues that might not be apparent in the development environment.
+* **Production**: This mode is used for live deployments. It involves optimized configurations for performance, security, and reliability. Resource allocations are typically higher, and debugging tools are minimized to ensure stability.
+
+## Deployment Mode Comparison
+
+| Feature | Development | Staging | Production |
+|-|-|-|-|
+| Build Resources | Builds will be run with 2x vCPUs | Builds will be run with 2x vCPUs | Builds will be run with 4x vCPUs |
+| Databases | Defang will provision resources optimized for burstable memory | | Defang will provision resources optimized for production |
+| Static Resources | | | Defang will provision a CDN |
+| Object Storage | S3 contents will be lost when deprovisioned. | | S3 contents will be retained if the bucket is deprovisioned. |
+| Deployment | Previous deployments will be spun down before new deployments are spun up. | | Rolling updates will be used to deploy new versions. |
+| Logging | Logs retained for 1 day to save costs. | | Logs retained for 30 days for compliance. |
+| Networking | Defang will provision a bastion box. | | Defang will provision a NAT gateway. |
+| DNS | Defang will provision shorter TTLs | | Defang will provision longer TTLs |

--- a/docs/concepts/generate.md
+++ b/docs/concepts/generate.md
@@ -6,17 +6,17 @@ sidebar_position: 100
 
 # Generate
 
-Defang includes an AI-driven assistant that translates natural language prompts to an outline for your project that you can then refine. The AI assistant is available through the [Defang CLI](../getting-started/installing.md).
+Defang includes an AI-driven agent that translates natural language prompts to an outline for your project that you can then refine. The AI agent is available through the [Defang CLI](../getting-started/installing.md).
 
 :::info
-The AI assistant is currently in preview and only supports a limited set of prompts, varying in complexity. We plan to expand the capabilities of the AI assistant in the future.
+The AI agent is currently in preview and only supports a limited set of prompts, varying in complexity. We plan to expand the capabilities of the AI agent in the future.
 :::
 
-We are working on expanding the range of supported prompts and improving the accuracy of the AI assistant. If you have any feedback or suggestions, please let us know by [opening an issue](https://github.com/DefangLabs/defang/issues/new).
+We are working on expanding the range of supported prompts and improving the accuracy of the AI agent. If you have any feedback or suggestions, please let us know by [opening an issue](https://github.com/DefangLabs/defang/issues/new).
 
 ## Example Prompts
 
-Here are some example prompts that the AI assistant can help you with:
+Here are some example prompts that the AI agent can help you with:
 
 ```
 A basic service with 2 REST endpoints. The default endpoint will be for health check and should return a JSON object like this: { "status": "OK" }. The /echo endpoint will echo back all request parameters in the response.

--- a/docs/concepts/managed-storage/managed-postgres.md
+++ b/docs/concepts/managed-storage/managed-postgres.md
@@ -38,6 +38,9 @@ You can also set the following optional environment variables to configure the m
 You can connect to the managed Postgres instance using the name of your service as the hostname, `POSTGRES_USER`, `POSTGRES_DB`, and `POSTGRES_PASSWORD` environment variables.
 
 ### Example
+:::info 
+For a smoother experience with Defang, we recommend using Postgres 14 for your container images. This version provides easier access and improved usability.
+:::
 
 ```yaml
   app:
@@ -55,7 +58,7 @@ You can connect to the managed Postgres instance using the name of your service 
       # reference config variables by using ${<config name>}
       CONNECTURL: postgresql://postgres:${POSTGRES_PASSWORD}@database:5432/postgres?sslmode=require
   database:
-    image: postgres:15
+    image: postgres:14
     x-defang-postgres: true
     ports:
       - mode: host
@@ -69,6 +72,7 @@ You can connect to the managed Postgres instance using the name of your service 
 
 ```
 
+<!-- 
 ### Major Version Updating of Engine
 
 To update the database engine you can simply update the image to a later version in your compose file and apply it via ```defang compose up --provider=aws```. In the example below, we change from Postgres 15 to 16.
@@ -85,4 +89,4 @@ to
 ```
 database:
   image: postgres:16
-```
+``` -->

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -21,7 +21,7 @@ description: Frequently asked questions about Defang.
 
 ### Can I access AWS storage services such as S3 or database services such as RDS? How?
 
-- Yes, you can access AWS services in your own AWS account as you normally would when you are [deploying to AWS with Defang](./providers/aws). In fact, you can access whatever other resources exist in the cloud account you are using for [Defang BYOC](./concepts/defang-byoc.md).
+- Yes, you can access AWS services in the AWS Dashboard as you normally would when you are [deploying to your AWS account](./providers/aws) using Defang. In fact, you can access whatever other resources exist in the cloud account you are using for [Defang BYOC](./concepts/defang-byoc.md).
 
 ### Can I run production apps with Defang?
 

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -53,7 +53,7 @@ description: Frequently asked questions about Defang.
 
 ### Do you plan to support other clouds?
 
-- While we currently support [AWS](./concepts/defang-byoc#aws) and [Digital Ocean](./concepts/defang-byoc#digitalocean), we plan to support other clouds in future releases, such [GCP](./providers/gcp.md) and [Azure](./providers/azure.md).
+- While we currently support [AWS](./concepts/defang-byoc#aws) and [DigitalOcean](./concepts/defang-byoc#digitalocean), we plan to support other clouds in future releases, such [GCP](./providers/gcp.md) and [Azure](./providers/azure.md).
 
 ### I'm having trouble running the binary on my Mac. What should I do?
 

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -13,7 +13,7 @@ description: Frequently asked questions about Defang.
 
 ### Can I bring my own AWS or other cloud account?
 
-- Yes! Please check out the [Defang BYOC](./concepts/defang-byoc.md) documentation for more information.
+- Yes! Defang makes it easy to deploy your application to your own cloud account. Please check out the [Defang BYOC](./concepts/defang-byoc.md) documentation for more information.
 
 ### On AWS, can I deploy to services such as EC2, EKS, or Lambda?
 
@@ -23,13 +23,37 @@ description: Frequently asked questions about Defang.
 
 - Yes, you can access whatever other resources exist in the cloud account you are using as a [Defang BYOC](./concepts/defang-byoc.md) Provider.
 
-### Do you plan to support other clouds?
-
-- While we currently support AWS as a [Defang BYOC](./concepts/defang-byoc.md) Provider, we plan to support other clouds in future releases, such as [Azure](./providers/azure.md) and [GCP](./providers/gcp.md).
-
 ### Can I run production apps with Defang?
 
-- The [Defang Playground](./concepts/defang-playground.md) is meant for testing and trial purposes only. Deployment of productions apps with [Defang BYOC](./concepts/defang-byoc.md) is not yet supported and disallowed by the [Terms of Service](https://defang.io/terms-service.html). If you are interested in running production apps, please [contact us](https://defang.io/#Contact-us).
+- Yes! Defang makes it easy to deploy your app on production-ready infrastructure in your own cloud account. For example, you can deploy your app to AWS with `defang up --provider=aws --mode=production`. Check out your preferred cloud provider on [Defang BYOC](./concepts/defang-byoc.md).
+
+### Does Defang support blue/green deployments?
+
+- Defang does not currently support Blue/Green deploys, but it does support rolling updates with the `production` deployment mode. `defang up --mode=production`.
+
+### Does Defang support rolling deployments?
+
+- Yes! Defang supports rolling updates with the `production` deployment mode. `defang up --mode=production`.
+
+### Can I cancel a deployment once it has started?
+
+- No. Once a deployment has started, it cannot be canceled. However, you can always deploy a new version of your app which will replace the current deployment.
+
+### Will deploying a new version of my app cause downtime?
+
+- If you have deployed your application with the `--mode=production` flag, Defang will use the _production_ deployment mode. This mode will provision your app with multiple replicas and will perform a rolling update to ensure zero downtime. If you use another deployment mode, you may experience downtime during the deployment, as defang will not provision multiple replicas to save cost.
+
+### Can I deploy multiple services at once?
+
+- Yes! You can deploy multiple services at once by defining them in a single compose.yaml file. When you run `defang compose up`, Defang will deploy all the services defined in the file at once.
+
+### Can I deploy a service that depends on another service?
+
+- Defang does not currently support service dependencies. All services will be deployed simultaneously. Defang will however run multiple healthchecks before marking a service as healthy and spinning down any previously deployed services when using the `production` deployment mode.
+
+### Do you plan to support other clouds?
+
+- While we currently support [AWS](./concepts/defang-byoc#aws) and [Digital Ocean](./concepts/defang-byoc#digitalocean), we plan to support other clouds in future releases, such [GCP](./providers/gcp.md) and [Azure](./providers/azure.md).
 
 ### I'm having trouble running the binary on my Mac. What should I do?
 
@@ -38,6 +62,8 @@ description: Frequently asked questions about Defang.
     2. Go to System Preferences > Privacy & Security > General.
     3. In the 'Allow applications downloaded from:' section, you should see a message about Defang being blocked. Click 'Open Anyway'.
     4. Alternatively, select the option "App Store and identified developers" to allow all applications from the App Store and identified developers to run.
+
+### Does Defang Support
 
 ## Warnings
 

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -53,7 +53,7 @@ description: Frequently asked questions about Defang.
 
 ### Do you plan to support other clouds?
 
-- While we currently support [AWS](./concepts/defang-byoc#aws) and [DigitalOcean](./concepts/defang-byoc#digitalocean), we plan to support other clouds in future releases, such as [GCP](./providers/gcp.md) and [Azure](./providers/azure.md).
+- While we currently support [AWS](./concepts/defang-byoc#aws) for production and [DigitalOcean](./concepts/defang-byoc#digitalocean) in preview, we plan to support other clouds in future releases, such as [GCP](./providers/gcp.md) and [Azure](./providers/azure.md).
 
 ### I'm having trouble running the binary on my Mac. What should I do?
 

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -21,7 +21,7 @@ description: Frequently asked questions about Defang.
 
 ### Can I access AWS storage services such as S3 or database services such as RDS? How?
 
-- Yes, you can access whatever other resources exist in the cloud account you are using as a [Defang BYOC](./concepts/defang-byoc.md) Provider.
+- Yes, you can access AWS services in your own AWS account as you normally would when you are [deploying to AWS with Defang](./providers/aws). In fact, you can access whatever other resources exist in the cloud account you are using for [Defang BYOC](./concepts/defang-byoc.md).
 
 ### Can I run production apps with Defang?
 

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -53,7 +53,7 @@ description: Frequently asked questions about Defang.
 
 ### Do you plan to support other clouds?
 
-- While we currently support [AWS](./concepts/defang-byoc#aws) and [DigitalOcean](./concepts/defang-byoc#digitalocean), we plan to support other clouds in future releases, such [GCP](./providers/gcp.md) and [Azure](./providers/azure.md).
+- While we currently support [AWS](./concepts/defang-byoc#aws) and [DigitalOcean](./concepts/defang-byoc#digitalocean), we plan to support other clouds in future releases, such as [GCP](./providers/gcp.md) and [Azure](./providers/azure.md).
 
 ### I'm having trouble running the binary on my Mac. What should I do?
 

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -63,8 +63,6 @@ description: Frequently asked questions about Defang.
     3. In the 'Allow applications downloaded from:' section, you should see a message about Defang being blocked. Click 'Open Anyway'.
     4. Alternatively, select the option "App Store and identified developers" to allow all applications from the App Store and identified developers to run.
 
-### Does Defang Support
-
 ## Warnings
 
 ### "The folder is not empty. Files may be overwritten."

--- a/docs/getting-started/getting-started.md
+++ b/docs/getting-started/getting-started.md
@@ -102,11 +102,11 @@ Congratulations! You've successfully deployed your first service with Defang. No
 
 Defang supports various ways of creating and deploying services to the cloud. The following tutorials dive into each one in more detail:
 
+1. [Deploy to your own cloud](/docs/tutorials/deploy-to-your-cloud)
 1. [Update the code and redeploy](/docs/getting-started/build-and-deploy)
-2. [Monitor your services](/docs/getting-started/monitor)
-3. [Deploy an outline using AI](/docs/tutorials/generate-new-code-using-ai)
-4. [Build and deploy your code](/docs/tutorials/deploy-code-compose)
-5. [Deploy existing containers](/docs/tutorials/deploy-container-using-the-cli)
-6. [Deploy using Pulumi](/docs/tutorials/deploy-using-pulumi)
+1. [Monitor your services](/docs/getting-started/monitor)
+1. [Deploy an outline using AI](/docs/tutorials/generate-new-code-using-ai)
+1. [Deploy existing containers](/docs/tutorials/deploy-container-using-the-cli)
+1. [Deploy using Pulumi](/docs/tutorials/deploy-using-pulumi)
 
 Choose the direction that seems the most interesting. If you have any questions, join the [Defang Discord](https://discord.gg/defang) and we'll be happy to help you out.

--- a/docs/intro.md
+++ b/docs/intro.md
@@ -10,7 +10,7 @@ description: Overview of Defang, a radically simpler way to develop, deploy, and
 
 Defang is a radically simpler way for developers to develop, deploy, and debug their cloud applications. Defang enables you to easily author cloud application in any language, build and deploy to the cloud with a single command, and iterate quickly with AI-assisted tooling.
 
-- The [Defang CLI](./getting-started/installing.md) includes an AI-driven assistant that translates natural language prompts to an outline for your project that you can then refine.
+- The [Defang CLI](./getting-started/installing.md) includes an AI-driven agent that translates natural language prompts to an outline for your project that you can then refine.
 - Defang can automatically build and deploy your project with a single command.
     - If you’re new to Defang, you can try deploying to the [Defang Playground](./concepts/defang-playground.md), a hosted environment to learn to use Defang with non-production workloads.
     - Once you’re ready, you can [deploy](./concepts/deployments.md) it to your own cloud account - we call this [Defang BYOC](./concepts/defang-byoc.md). Defang takes care of all the heavy lifting such as configuring networking, security, [observability](./concepts/observability.md) and all the other details that usually slow down the average cloud developer.
@@ -22,8 +22,8 @@ Defang provides a streamlined experience to develop, deploy, observe, and update
 
 - Support for [various types of applications](./use-cases/use-cases.md): Web services and APIs, mobile app backends, ML services, hosting LLMs, etc.
 - Support for your programming [language of choice](./samples.md): Node.js, Python, Golang, or anything else you can package in a Dockerfile.
-- Built-in AI assistant to go [from natural language prompt to an outline project](./concepts/generate.md)
-- Built-in AI assistant to help you [debug your cloud applications](./concepts/debug.md)
+- Built-in AI agent to go [from natural language prompt to an outline project](./concepts/generate.md)
+- Built-in AI agent to help you [debug your cloud applications](./concepts/debug.md)
 - Automated [Dockerfile builds](./concepts/deployments.md)
 - Support for [pre-built Docker containers](./tutorials/deploy-container-using-the-cli.mdx), from public or private image registries
 - Ability to express your project configuration using a [Docker Compose YAML](./concepts/compose.md) file

--- a/docs/intro.md
+++ b/docs/intro.md
@@ -4,6 +4,7 @@ title: Overview
 description: Overview of Defang, a radically simpler way to build, deploy, and optimize production-ready cloud apps.
 ---
 
+<iframe width="560" height="315" src="https://www.youtube.com/embed/afglsBYieuc?si=iKgUX4ejz7AixxqQ" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
 
 ### What is Defang?
 
@@ -31,4 +32,3 @@ Defang provides a streamlined experience to develop, deploy, observe, and update
 - [One-command deployments](./getting-started/installing.md)
 - Support for [GPUs](./concepts/resources.md)
 - Support for Infra-as-Code via the [Defang Pulumi provider](./concepts/pulumi.md)
-

--- a/docs/intro.md
+++ b/docs/intro.md
@@ -1,7 +1,7 @@
 ---
 sidebar_position: 100
 title: Overview
-description: Overview of Defang, a radically simpler way to build, deploy, and optimize production-ready cloud apps.
+description: Overview of Defang, a radically simpler way to develop, deploy, and debug production-ready cloud apps.
 ---
 
 <iframe width="560" height="315" src="https://www.youtube.com/embed/afglsBYieuc?si=iKgUX4ejz7AixxqQ" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>

--- a/docs/providers/_category_.json
+++ b/docs/providers/_category_.json
@@ -1,6 +1,6 @@
 {
   "label": "Providers",
-  "position": 350,
+  "position": 400,
   "link": {
     "type": "generated-index",
     "description": "Defang allows you to use your own cloud accounts to deploy your applications. Click on a link below to read documentation about specific providers."

--- a/docs/providers/aws/aws.md
+++ b/docs/providers/aws/aws.md
@@ -17,7 +17,7 @@ Why should you use Defang with AWS? Defang allows you to easily create and manag
 Getting started with the Defang BYOC AWS Provider is easy. The first step is to [authenticate your shell](https://docs.aws.amazon.com/cli/latest/userguide/cli-chap-configure.html) with AWS as an admin user. The authenticated user should be an IAM admin because Defang will need permission to create resources and IAM roles in your account.
 
 :::tip
-If you have the aws CLI installed, you should be able to successfully run `aws sts get-caller-identity` and see your account ID.
+If you have the AWS CLI installed, you should be able to successfully run `aws sts get-caller-identity` and see your account ID.
 :::
 
 Use the `--provider=aws` flag to tell the Defang CLI to use the AWS Provider or set the `DEFANG_PROVIDER` environment variable to `aws`.

--- a/docs/providers/digitalocean/digitalocean.md
+++ b/docs/providers/digitalocean/digitalocean.md
@@ -13,9 +13,21 @@ This feature is available for Public Preview as of October 2024. This page will 
 Why should you use Defang with DigitalOcean? Defang allows you to easily create and manage full, scalable applications with DigitalOcean. Defang aims to make it easier to deploy your services to the cloud. DigitalOcean is one of the most popular cloud providers in the world and with Defang, you dont have to waste your time understanding the complexities and challenges of the DigitalOcean platform. Let Defang do it for you and spend more time working on whats important to you!
 
 ## Getting Started
-To get started with the Defang BYOC DigitalOcean Provider, first [install the latest version of the Defang CLI](../getting-started#authenticate-with-defang). Next make sure you have signed up for a [DigitalOcean account](https://try.digitalocean.com/freetrialoffer/).  
 
-After signing up for your account, be sure to setup your [personal access token](https://docs.digitalocean.com/reference/api/create-personal-access-token/) as well as your [Spaces access key](https://docs.digitalocean.com/products/spaces/how-to/manage-access/).  Next, save these values as environment variables with the names `DIGITALOCEAN_TOKEN`, `SPACES_ACCESS_KEY_ID`, and `SPACES_SECRET_ACCESS_KEY`. 
+### Install Defang
+
+To get started with the Defang BYOC DigitalOcean Provider, first [install the latest version of the Defang CLI](../getting-started#authenticate-with-defang).
+
+### Sign up for DigitalOcean
+Next make sure you have signed up for a [DigitalOcean account](https://try.digitalocean.com/freetrialoffer/).
+
+### Authenticate with DigitalOcean
+After signing up for your account, be sure to setup your [personal access token](https://docs.digitalocean.com/reference/api/create-personal-access-token/). Defang will need to find this value in your shell as the `DIGITALOCEAN_TOKEN` environment variable.
+
+### Authenticate with DigitalOcean Spaces
+You will also need a [Digital Ocean Spaces access key](https://docs.digitalocean.com/products/spaces/how-to/manage-access/). Defang will need to find this value in your shell as the `SPACES_ACCESS_KEY_ID`, and `SPACES_SECRET_ACCESS_KEY` environment variables.
+
+### Configure your shell environment
 
 ```bash
 export DIGITALOCEAN_TOKEN=<your-token>
@@ -23,7 +35,11 @@ export SPACES_ACCESS_KEY_ID=<your-key-id>
 export SPACES_SECRET_ACCESS_KEY=<your-key>
 ```
 
-The Defang CLI will automatically check if they are set before running. Once you are ready to go, add the `--provider=digitalocean` to your command to tell the Defang CLI to use the DigitalOcean provider.
+The Defang CLI will automatically check if these envinonment variables are set before running.
+
+### Deploy your project to DigitalOcean
+
+Once you are ready to go, add the `--provider=digitalocean` to your command to tell the Defang CLI to use the DigitalOcean provider.
 
 ```bash
 $ defang up --provider=digitalocean
@@ -33,7 +49,7 @@ $ export DEFANG_PROVIDER=digitalocean
 
 ## Region
 
-The Defang BYOC DigitalOcean Provider will use the region specified in the `REGION` environment variable. For a list of regions available in DigitalOcean, see the [region documentation](https://docs.digitalocean.com/platform/regional-availability/#app-platform-availability). 
+The Defang BYOC DigitalOcean Provider will use the region specified in the `REGION` environment variable. For a list of regions available in DigitalOcean, see the [region documentation](https://docs.digitalocean.com/platform/regional-availability/#app-platform-availability).
 
 ## Architecture
 
@@ -45,7 +61,7 @@ To deploy your services, the Defang CLI packages your code and uploads it to a [
 
 ### Runtime
 
-The Provider runs your workloads using the [DigitalOcean App Platform](https://docs.digitalocean.com/products/app-platform/). 
+The Provider runs your workloads using the [DigitalOcean App Platform](https://docs.digitalocean.com/products/app-platform/).
 
 ### Secrets
 

--- a/docs/providers/digitalocean/digitalocean.md
+++ b/docs/providers/digitalocean/digitalocean.md
@@ -25,7 +25,7 @@ Next make sure you have signed up for a [DigitalOcean account](https://try.digit
 After signing up for your account, be sure to setup your [personal access token](https://docs.digitalocean.com/reference/api/create-personal-access-token/). Defang will need to find this value in your shell as the `DIGITALOCEAN_TOKEN` environment variable.
 
 ### Authenticate with DigitalOcean Spaces
-You will also need a [Digital Ocean Spaces access key](https://docs.digitalocean.com/products/spaces/how-to/manage-access/). Defang will need to find this value in your shell as the `SPACES_ACCESS_KEY_ID`, and `SPACES_SECRET_ACCESS_KEY` environment variables.
+You will also need a [DigitalOcean Spaces access key](https://docs.digitalocean.com/products/spaces/how-to/manage-access/). Defang will need to find this value in your shell as the `SPACES_ACCESS_KEY_ID`, and `SPACES_SECRET_ACCESS_KEY` environment variables.
 
 ### Configure your shell environment
 

--- a/docs/providers/gcp.md
+++ b/docs/providers/gcp.md
@@ -7,5 +7,5 @@ sidebar_position: 3000
 # GCP
 
 :::info
-We will be working on GCP support in the future. If you are interested in GCP support, please vote on [this issue](https://github.com/DefangLabs/defang/issues/58).
+GCP support is coming soon to Defang! 
 :::

--- a/docs/samples.md
+++ b/docs/samples.md
@@ -1,7 +1,7 @@
 ---
 title: Samples
 description: Sample projects to help you launch services faster with Defang.
-sidebar_position: 500
+sidebar_position: 600
 ---
 
 import {Button, ButtonGroup, FormGroup, FormLabel} from "@mui/material"

--- a/docs/tutorials/_category_.json
+++ b/docs/tutorials/_category_.json
@@ -1,9 +1,8 @@
 {
   "label": "Tutorials",
-  "position": 400,
+  "position": 300,
   "link": {
     "type": "generated-index",
     "description": "Check out these tutorials to learn more about the Defang platform."
   }
 }
-

--- a/docs/tutorials/deploy-container-using-the-cli.mdx
+++ b/docs/tutorials/deploy-container-using-the-cli.mdx
@@ -1,9 +1,9 @@
 ---
-title: Deploy pre-built container
+title: Deploy existing container
 sidebar_position: 200
 ---
 
-# Deploy container using the CLI
+# Deploy an Existing Container Using the CLI
 
 This example is useful if you already have a Docker container built manually or through a CI/CD system and have that the resulting image is available in a public or private repository accessible by Defang.
 

--- a/docs/tutorials/deploy-to-aws.mdx
+++ b/docs/tutorials/deploy-to-aws.mdx
@@ -1,10 +1,10 @@
 ---
 title: Deploy to AWS
 description: Defang allows you deploy to your own Amazon Web Services (AWS) account.
-sidebar_position: 10
+sidebar_position: 11
 ---
 
-# Deploying to Amazon Web Services (AWS) with Defang
+# Deploying to Amazon Web Services (AWS) With Defang
 
 This tutorial will show you how to deploy your services to your own AWS account using Defang.
 

--- a/docs/tutorials/deploy-to-aws.mdx
+++ b/docs/tutorials/deploy-to-aws.mdx
@@ -28,6 +28,10 @@ Once you've done that, Defang will look for your AWS credentials in your shell e
 * the `AWS_PROFILE` environment variable
 * or, the `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` environment variables
 
+:::tip
+If you have the AWS CLI installed (which is not required in order to use the Defang CLI), you can verify that you've authenticated to AWS by running `aws sts get-caller-identity` and see your account ID.
+:::
+
 ## Step 3 - Deploy
 
 Invoke the `defang up` CLI command with the `--provider=aws` flag or set the `DEFANG_PROVIDER=aws` environment variable.

--- a/docs/tutorials/deploy-to-aws.mdx
+++ b/docs/tutorials/deploy-to-aws.mdx
@@ -1,0 +1,49 @@
+---
+title: Deploy to Amazon Web Services (AWS) with Defang
+description: Defang allows you deploy to your own Amazon Web Services (AWS) account.
+sidebar_position: 10
+---
+
+# Deploying to Amazon Web Services (AWS) with Defang
+
+This tutorial will show you how to deploy your services to your own AWS account using Defang.
+
+## Pre-requisites
+* [A Dockerfile in your project](https://docs.docker.com/get-started/docker-concepts/building-images/writing-a-dockerfile/)
+* [A `compose.yaml` file in your project](https://docs.docker.com/compose/gettingstarted/)
+* [A Defang Account](/getting-started/authenticating)
+* [The Defang CLI](/getting-started/installing)
+* [AWS Account Credentials](https://docs.aws.amazon.com/cli/latest/userguide/cli-chap-authentication.html)
+
+## Deploy your project to AWS
+
+1. Navigate to the directory where your project is located:
+```bash
+$ cd path/to/your/project
+```
+
+2. Authenticate Defang to use your AWS Account
+
+Defang will look for your AWS credentials in your shell environment.
+
+Defang will expect to find one of the following credential sets:
+* the `AWS_PROFILE` environment variable
+* or, the `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` environment variables
+
+3. Deploy
+
+Invoke the `defang up` CLI command with the `--provider=aws` flag or set the `DEFANG_PROVIDER=aws` environment variable.
+
+For example:
+
+```bash
+$ defang up --provider=aws
+```
+
+4. Inspect your deployment
+
+Defang will provision resources in your AWS account and deploy your services. You can inspect the resources created in your AWS dashboard.
+
+***
+
+For a deeper discussion of the Defang AWS Architecture, including a list of the resources we provision in your account, see our [AWS Provider docs](./providers/aws/aws).

--- a/docs/tutorials/deploy-to-aws.mdx
+++ b/docs/tutorials/deploy-to-aws.mdx
@@ -1,5 +1,5 @@
 ---
-title: Deploy to Amazon Web Services (AWS) with Defang
+title: Deploy to AWS
 description: Defang allows you deploy to your own Amazon Web Services (AWS) account.
 sidebar_position: 10
 ---

--- a/docs/tutorials/deploy-to-aws.mdx
+++ b/docs/tutorials/deploy-to-aws.mdx
@@ -15,22 +15,20 @@ This tutorial will show you how to deploy your services to your own AWS account 
 * [The Defang CLI](/docs/getting-started/installing)
 * [AWS Account Credentials](https://docs.aws.amazon.com/cli/latest/userguide/cli-chap-authentication.html)
 
-## Deploy your project to AWS
-
-1. Navigate to the directory where your project is located:
+## Step 1 - Navigate to your project directory
+Head to the folder where your project is located.
 ```bash
 $ cd path/to/your/project
 ```
 
-2. Authenticate Defang to use your AWS Account
+## Step 2 - Authenticate Defang to use your AWS Account
 
-Defang will look for your AWS credentials in your shell environment.
-
-Defang will expect to find one of the following credential sets:
+There are many ways to authenticate your [AWS account](https://docs.aws.amazon.com/cli/latest/userguide/cli-chap-authentication.html). 
+Once you've done that, Defang will look for your AWS credentials in your shell environment and expect to find one of the following credential sets:
 * the `AWS_PROFILE` environment variable
 * or, the `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` environment variables
 
-3. Deploy
+## Step 3 - Deploy
 
 Invoke the `defang up` CLI command with the `--provider=aws` flag or set the `DEFANG_PROVIDER=aws` environment variable.
 
@@ -40,7 +38,7 @@ For example:
 $ defang up --provider=aws
 ```
 
-4. Inspect your deployment
+## Step 4 - Inspect your deployment
 
 Defang will provision resources in your AWS account and deploy your services. You can inspect the resources created in your AWS dashboard.
 

--- a/docs/tutorials/deploy-to-aws.mdx
+++ b/docs/tutorials/deploy-to-aws.mdx
@@ -11,8 +11,8 @@ This tutorial will show you how to deploy your services to your own AWS account 
 ## Pre-requisites
 * [A Dockerfile in your project](https://docs.docker.com/get-started/docker-concepts/building-images/writing-a-dockerfile/)
 * [A `compose.yaml` file in your project](https://docs.docker.com/compose/gettingstarted/)
-* [A Defang Account](/getting-started/authenticating)
-* [The Defang CLI](/getting-started/installing)
+* [A Defang Account](/docs/getting-started/authenticating)
+* [The Defang CLI](/docs/getting-started/installing)
 * [AWS Account Credentials](https://docs.aws.amazon.com/cli/latest/userguide/cli-chap-authentication.html)
 
 ## Deploy your project to AWS
@@ -46,4 +46,4 @@ Defang will provision resources in your AWS account and deploy your services. Yo
 
 ***
 
-For a deeper discussion of the Defang AWS Architecture, including a list of the resources we provision in your account, see our [AWS Provider docs](./providers/aws/aws).
+For a deeper discussion of the Defang AWS Architecture, including a list of the resources we provision in your account, see our [AWS Provider docs](/docs/providers/aws).

--- a/docs/tutorials/deploy-to-digitalocean.mdx
+++ b/docs/tutorials/deploy-to-digitalocean.mdx
@@ -1,10 +1,10 @@
 ---
 title: Deploy to Digital Ocean
 description: Defang allows you deploy to your own Digital Ocean account.
-sidebar_position: 10
+sidebar_position: 11
 ---
 
-# Deploying to Digital Ocean with Defang
+# Deploying to Digital Ocean With Defang
 
 This tutorial will show you how to deploy your services to your own Digital Ocean account using Defang.
 

--- a/docs/tutorials/deploy-to-digitalocean.mdx
+++ b/docs/tutorials/deploy-to-digitalocean.mdx
@@ -1,0 +1,50 @@
+---
+title: Deploy to Digital Ocean with Defang
+description: Defang allows you deploy to your own Digital Ocean account.
+sidebar_position: 10
+---
+
+# Deploying to Digital Ocean with Defang
+
+This tutorial will show you how to deploy your services to your own Digital Ocean account using Defang.
+
+## Pre-requisites
+* [A Dockerfile in your project](https://docs.docker.com/get-started/docker-concepts/building-images/writing-a-dockerfile/)
+* [A `compose.yaml` file in your project](https://docs.docker.com/compose/gettingstarted/)
+* [A Defang Account](/getting-started/authenticating)
+* [The Defang CLI](/getting-started/installing)
+* [Digital Ocean Account Credentials](/providers/digitalocean#getting-started)
+* [Digital Ocean Spaces Access Keys](/providers/digitalocean#getting-started)
+
+## Deploy your project to Digital Ocean
+
+1. Navigate to the directory where your project is located:
+```bash
+$ cd path/to/your/project
+```
+
+2. Authenticate Defang to use your Digital Ocean Account
+
+Defang will look for your Digital Ocean credentials in your shell environment.
+
+Defang will expect to find the following credentials:
+* the `DIGITALOCEAN_TOKEN` environment variable
+* and, the `SPACES_ACCESS_KEY_ID` and `SPACES_SECRET_ACCESS_KEY` environment variables
+
+3. Deploy
+
+Invoke the `defang up` CLI command with the `--provider=do` flag or set the `DEFANG_PROVIDER=do` environment variable.
+
+For example:
+
+```bash
+$ defang up --provider=do
+```
+
+4. Inspect your deployment
+
+Defang will provision resources in your Digital Ocean account and deploy your services. You can inspect the resources created in your Digital Ocean dashboard.
+
+***
+
+For a deeper discussion of the Defang Digital Ocean Architecture, see our [Digital Ocean Provider docs](./providers/digitalocean/digitalocean).

--- a/docs/tutorials/deploy-to-digitalocean.mdx
+++ b/docs/tutorials/deploy-to-digitalocean.mdx
@@ -1,29 +1,31 @@
 ---
-title: Deploy to Digital Ocean
-description: Defang allows you deploy to your own Digital Ocean account.
+title: Deploy to DigitalOcean
+description: Defang allows you deploy to your own DigitalOcean account.
 sidebar_position: 11
 ---
 
-# Deploying to Digital Ocean With Defang
+# Deploying to DigitalOcean With Defang
 
-This tutorial will show you how to deploy your services to your own Digital Ocean account using Defang.
+This tutorial will show you how to deploy your services to your own DigitalOcean account using Defang.
 
 ## Pre-requisites
 * [A Dockerfile in your project](https://docs.docker.com/get-started/docker-concepts/building-images/writing-a-dockerfile/)
 * [A `compose.yaml` file in your project](https://docs.docker.com/compose/gettingstarted/)
 * [A Defang Account](/docs/getting-started/authenticating)
 * [The Defang CLI](/docs/getting-started/installing)
-* [Digital Ocean Account Credentials](/docs/providers/digitalocean#getting-started)
-* [Digital Ocean Spaces Access Keys](/docs/providers/digitalocean#getting-started)
+* [DigitalOcean Account Credentials](/docs/providers/digitalocean#getting-started)
+* [DigitalOcean Spaces Access Keys](/docs/providers/digitalocean#getting-started)
 
 ## Step 1 - Navigate to your project directory
+
+Head to the folder where your project is located.
 ```bash
 $ cd path/to/your/project
 ```
 
-## Step 2 - Authenticate Defang to use your Digital Ocean Account
+## Step 2 - Authenticate Defang to use your Digital cean Account
 
-Defang will look for your Digital Ocean credentials in your shell environment and expect to find the following credentials:
+Defang will look for your DigitalOcean credentials in your shell environment and expect to find the following credentials:
 * the `DIGITALOCEAN_TOKEN` environment variable
 * and, the `SPACES_ACCESS_KEY_ID` and `SPACES_SECRET_ACCESS_KEY` environment variables
 
@@ -39,8 +41,8 @@ $ defang up --provider=do
 
 ## Step 4 - Inspect your deployment
 
-Defang will provision resources in your Digital Ocean account and deploy your services. You can inspect the resources created in your Digital Ocean dashboard.
+Defang will provision resources in your DigitalOcean account and deploy your services. You can inspect the resources created in your DigitalOcean dashboard.
 
 ***
 
-For a deeper discussion of the Defang Digital Ocean Architecture, see our [Digital Ocean Provider docs](/docs/providers/digitalocean).
+For a deeper discussion of the Defang DigitalOcean Architecture, see our [DigitalOcean Provider docs](/docs/providers/digitalocean).

--- a/docs/tutorials/deploy-to-digitalocean.mdx
+++ b/docs/tutorials/deploy-to-digitalocean.mdx
@@ -16,22 +16,18 @@ This tutorial will show you how to deploy your services to your own Digital Ocea
 * [Digital Ocean Account Credentials](/docs/providers/digitalocean#getting-started)
 * [Digital Ocean Spaces Access Keys](/docs/providers/digitalocean#getting-started)
 
-## Deploy your project to Digital Ocean
-
-1. Navigate to the directory where your project is located:
+## Step 1 - Navigate to your project directory
 ```bash
 $ cd path/to/your/project
 ```
 
-2. Authenticate Defang to use your Digital Ocean Account
+## Step 2 - Authenticate Defang to use your Digital Ocean Account
 
-Defang will look for your Digital Ocean credentials in your shell environment.
-
-Defang will expect to find the following credentials:
+Defang will look for your Digital Ocean credentials in your shell environment and expect to find the following credentials:
 * the `DIGITALOCEAN_TOKEN` environment variable
 * and, the `SPACES_ACCESS_KEY_ID` and `SPACES_SECRET_ACCESS_KEY` environment variables
 
-3. Deploy
+## Step 3 - Deploy
 
 Invoke the `defang up` CLI command with the `--provider=do` flag or set the `DEFANG_PROVIDER=do` environment variable.
 
@@ -41,7 +37,7 @@ For example:
 $ defang up --provider=do
 ```
 
-4. Inspect your deployment
+## Step 4 - Inspect your deployment
 
 Defang will provision resources in your Digital Ocean account and deploy your services. You can inspect the resources created in your Digital Ocean dashboard.
 

--- a/docs/tutorials/deploy-to-digitalocean.mdx
+++ b/docs/tutorials/deploy-to-digitalocean.mdx
@@ -23,7 +23,7 @@ Head to the folder where your project is located.
 $ cd path/to/your/project
 ```
 
-## Step 2 - Authenticate Defang to use your Digital cean Account
+## Step 2 - Authenticate Defang to use your DigitalOcean Account
 
 Defang will look for your DigitalOcean credentials in your shell environment and expect to find the following credentials:
 * the `DIGITALOCEAN_TOKEN` environment variable

--- a/docs/tutorials/deploy-to-digitalocean.mdx
+++ b/docs/tutorials/deploy-to-digitalocean.mdx
@@ -1,5 +1,5 @@
 ---
-title: Deploy to Digital Ocean with Defang
+title: Deploy to Digital Ocean
 description: Defang allows you deploy to your own Digital Ocean account.
 sidebar_position: 10
 ---

--- a/docs/tutorials/deploy-to-digitalocean.mdx
+++ b/docs/tutorials/deploy-to-digitalocean.mdx
@@ -11,10 +11,10 @@ This tutorial will show you how to deploy your services to your own Digital Ocea
 ## Pre-requisites
 * [A Dockerfile in your project](https://docs.docker.com/get-started/docker-concepts/building-images/writing-a-dockerfile/)
 * [A `compose.yaml` file in your project](https://docs.docker.com/compose/gettingstarted/)
-* [A Defang Account](/getting-started/authenticating)
-* [The Defang CLI](/getting-started/installing)
-* [Digital Ocean Account Credentials](/providers/digitalocean#getting-started)
-* [Digital Ocean Spaces Access Keys](/providers/digitalocean#getting-started)
+* [A Defang Account](/docs/getting-started/authenticating)
+* [The Defang CLI](/docs/getting-started/installing)
+* [Digital Ocean Account Credentials](/docs/providers/digitalocean#getting-started)
+* [Digital Ocean Spaces Access Keys](/docs/providers/digitalocean#getting-started)
 
 ## Deploy your project to Digital Ocean
 
@@ -47,4 +47,4 @@ Defang will provision resources in your Digital Ocean account and deploy your se
 
 ***
 
-For a deeper discussion of the Defang Digital Ocean Architecture, see our [Digital Ocean Provider docs](./providers/digitalocean/digitalocean).
+For a deeper discussion of the Defang Digital Ocean Architecture, see our [Digital Ocean Provider docs](/docs/providers/digitalocean).

--- a/docs/tutorials/deploy-to-gcp.mdx
+++ b/docs/tutorials/deploy-to-gcp.mdx
@@ -1,0 +1,9 @@
+---
+title: Deploy to Google Cloud Platform (GCP) with Defang
+description: Defang allows you deploy to your own Google Cloud Platform (GCP) account.
+sidebar_position: 10
+---
+
+# Deploying to Google Cloud Platform (GCP) with Defang
+
+Coming soon!

--- a/docs/tutorials/deploy-to-gcp.mdx
+++ b/docs/tutorials/deploy-to-gcp.mdx
@@ -7,3 +7,8 @@ sidebar_position: 10
 # Deploying to Google Cloud Platform (GCP) with Defang
 
 Coming soon!
+
+---
+
+For a deeper discussion of the Defang GCP Architecture, see our [GCP docs](/docs/providers/gcp).
+

--- a/docs/tutorials/deploy-to-gcp.mdx
+++ b/docs/tutorials/deploy-to-gcp.mdx
@@ -1,10 +1,10 @@
 ---
 title: Deploy to GCP
 description: Defang allows you deploy to your own Google Cloud Platform (GCP) account.
-sidebar_position: 10
+sidebar_position: 11
 ---
 
-# Deploying to Google Cloud Platform (GCP) with Defang
+# Deploying to Google Cloud Platform (GCP) With Defang
 
 Coming soon!
 

--- a/docs/tutorials/deploy-to-gcp.mdx
+++ b/docs/tutorials/deploy-to-gcp.mdx
@@ -1,5 +1,5 @@
 ---
-title: Deploy to Google Cloud Platform (GCP) with Defang
+title: Deploy to GCP
 description: Defang allows you deploy to your own Google Cloud Platform (GCP) account.
 sidebar_position: 10
 ---

--- a/docs/tutorials/deploy-to-your-cloud.mdx
+++ b/docs/tutorials/deploy-to-your-cloud.mdx
@@ -4,14 +4,14 @@ description: Defang allows you deploy to your own cloud account.
 sidebar_position: 10
 ---
 
-# Deploying to your cloud with Defang
+# Deploying to Your Cloud With Defang
 
 This tutorial will show you how to deploy your services to your own cloud account using Defang.
 
-::: tip
-::: Defang makes it easier to deploy to any cloud—in your *own* cloud accounts. We refer to this as bring-your-own-cloud (BYOC).
+:::tip
+Defang makes it easier to deploy to any cloud—in your *own* cloud accounts. We refer to this as bring-your-own-cloud (BYOC).
+If you aren't ready to deploy to your own cloud account, you can use the Defang Playground to get a feel for how Defang works for free.
 :::
-::: If you aren't ready to deploy to your own cloud account, you can use the Defang Playground to get a feel for how Defang works for free.
 
 ## Choose your cloud
 

--- a/docs/tutorials/deploy-to-your-cloud.mdx
+++ b/docs/tutorials/deploy-to-your-cloud.mdx
@@ -1,0 +1,22 @@
+---
+title: Deploy to your cloud with Defang
+description: Defang allows you deploy to your own cloud account.
+sidebar_position: 10
+---
+
+# Deploying to your cloud with Defang
+
+This tutorial will show you how to deploy your services to your own cloud account using Defang.
+
+::: tip
+::: Defang makes it easier to deploy to any cloud—in your *own* cloud accounts. We refer to this as bring-your-own-cloud (BYOC).
+:::
+::: If you aren't ready to deploy to your own cloud account, you can use the Defang Playground to get a feel for how Defang works for free.
+
+## Choose your cloud
+
+The first step is to choose which cloud provider you want to deploy to. Defang supports the following cloud providers:
+
+* [AWS](./tutorials/deploy-to-aws)
+* [DigitalOcean](./tutorials/deploy-to-digitalocean)
+* [GCP](./tutorials/deploy-to-gcp)

--- a/docs/tutorials/deploy-to-your-cloud.mdx
+++ b/docs/tutorials/deploy-to-your-cloud.mdx
@@ -1,5 +1,5 @@
 ---
-title: Deploy to your cloud with Defang
+title: Deploy to your cloud
 description: Defang allows you deploy to your own cloud account.
 sidebar_position: 10
 ---

--- a/docs/tutorials/deploy-to-your-cloud.mdx
+++ b/docs/tutorials/deploy-to-your-cloud.mdx
@@ -17,6 +17,6 @@ This tutorial will show you how to deploy your services to your own cloud accoun
 
 The first step is to choose which cloud provider you want to deploy to. Defang supports the following cloud providers:
 
-* [AWS](./tutorials/deploy-to-aws)
-* [DigitalOcean](./tutorials/deploy-to-digitalocean)
-* [GCP](./tutorials/deploy-to-gcp)
+* [AWS](/docs/tutorials/deploy-to-aws)
+* [DigitalOcean](/docs/tutorials/deploy-to-digitalocean)
+* [GCP](/docs/tutorials/deploy-to-gcp)

--- a/docs/tutorials/deploy-using-pulumi.mdx
+++ b/docs/tutorials/deploy-using-pulumi.mdx
@@ -3,7 +3,7 @@ title: Build and deploy using Pulumi
 sidebar_position: 400
 ---
 
-# Deploy using Pulumi
+# Deploy Using Pulumi
 
 <iframe width="560" height="315" src="https://www.youtube.com/embed/A4uiP5FIgg0?si=BHZLOxN4noJ56f7x" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
 

--- a/docs/tutorials/deploy-with-gpu.mdx
+++ b/docs/tutorials/deploy-with-gpu.mdx
@@ -5,7 +5,7 @@ sidebar_position: 500
 
 # Deploy a GPU-Powered Application With Defang
 
-This tutorial guides you to create and deploy a GPU-powered application on AWS using Defang and Mistral. We will walk you through the whole deployment process based on this [Deploying Mistral with vLLM](https://github.com/DefangLabs/defang/tree/main/samples/other/vllm) sample.
+This tutorial guides you to create and deploy a GPU-powered application on AWS using Defang and Mistral. We will walk you through the whole deployment process based on this [Deploying Mistral with vLLM](https://github.com/DefangLabs/samples/tree/main/samples/vllm) sample.
 
 <iframe width="560" height="315" src="https://www.youtube.com/embed/kynFa2zU7hQ?si=qdV0xa6vkhMFJ6qv" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
 
@@ -25,11 +25,11 @@ This process can take a few days for AWS to approve.
 
 This sample requires a HugoingFace token to download the model. You can get a token by signing up at [HuggingFace](https://huggingface.co/join) and then going to [your settings](https://huggingface.co/settings/tokens) to get your token.
 
-## Step 1: Clone the sample project
+## Step 1 - Clone the sample project
 
-You'll need to clone [this sample](https://github.com/DefangLabs/defang/tree/main/samples/other/vllm) to go through this tutorial.
+You'll need to clone [this sample](https://github.com/DefangLabs/samples/tree/main/samples/vllm) to go through this tutorial.
 
-## Step 2: Check your [Defang BYOC](../concepts/defang-byoc.md) settings
+## Step 2 - Check your [Defang BYOC](../concepts/defang-byoc.md) settings
 
 * Make sure you [install the latest version of the Defang CLI](../getting-started/installing.md)
 * Then, make sure you have properly [authenticated your AWS account](https://docs.aws.amazon.com/cli/latest/userguide/cli-chap-configure.html). The Defang CLI makes use of AWS environment variables like `AWS_PROFILE`, `AWS_REGION`, `AWS_ACCESS_KEY_ID`, and `AWS_SECRET_ACCESS_KEY`, so make sure the correct values are set for those.
@@ -40,7 +40,7 @@ aws sts get-caller-identity
 ```
 
 
-## Step 2: Prepare your Environment
+## Step 3 - Prepare your Environment
 * Log into your Defang account
 ```bash
 defang login
@@ -54,7 +54,7 @@ defang config set --name HF_TOKEN
 [Configuration](../concepts/configuration.md) stores your sensitive information such as API keys, passwords, and other credentials for you.
 
 
-## Step 3: Explore the Compose File
+## Step 4 - Explore the Compose File
 
 The `compose.yml` file is where you define your services and their configurations.
 
@@ -153,10 +153,10 @@ You can see here how Defang's [networking](../concepts//networking.mdx) works. T
 ```
 
 
-## Step 4: Deploy to Your Own AWS Account with Defang
+## Step 5 - Deploy to Your Own AWS Account with Defang
 
 Run the following command to deploy your service:
 
 ```bash
-defang compose up
+defang compose up --provider=aws
 ```

--- a/docs/tutorials/deploy-with-gpu.mdx
+++ b/docs/tutorials/deploy-with-gpu.mdx
@@ -3,7 +3,7 @@ title: Deploy a GPU-powered application
 sidebar_position: 500
 ---
 
-# Deploy a GPU-powered application with Defang
+# Deploy a GPU-Powered Application With Defang
 
 This tutorial guides you to create and deploy a GPU-powered application on AWS using Defang and Mistral. We will walk you through the whole deployment process based on this [Deploying Mistral with vLLM](https://github.com/DefangLabs/defang/tree/main/samples/other/vllm) sample.
 

--- a/docs/tutorials/deploy-with-gpu.mdx
+++ b/docs/tutorials/deploy-with-gpu.mdx
@@ -34,11 +34,9 @@ You'll need to clone [this sample](https://github.com/DefangLabs/samples/tree/ma
 * Make sure you [install the latest version of the Defang CLI](../getting-started/installing.md)
 * Then, make sure you have properly [authenticated your AWS account](https://docs.aws.amazon.com/cli/latest/userguide/cli-chap-configure.html). The Defang CLI makes use of AWS environment variables like `AWS_PROFILE`, `AWS_REGION`, `AWS_ACCESS_KEY_ID`, and `AWS_SECRET_ACCESS_KEY`, so make sure the correct values are set for those.
 
-If you use the AWS CLI, you can verify that your are authenticated against AWS using the following command (note that the AWS CLI itself is not required to use the defang cli in BYOC mode):
-```bash
-aws sts get-caller-identity
-```
-
+:::tip
+If you have the AWS CLI installed (which is not required in order to use the Defang CLI), you can verify that you've authenticated to AWS by running `aws sts get-caller-identity` and see your account ID.
+:::
 
 ## Step 3 - Prepare your Environment
 * Log into your Defang account

--- a/docs/tutorials/generate-new-code-using-ai.mdx
+++ b/docs/tutorials/generate-new-code-using-ai.mdx
@@ -3,7 +3,7 @@ title: Deploy an outline using AI
 sidebar_position: 50
 ---
 
-# Deploy an outline using AI
+# Deploy an Outline of a Project Using AI
 
 Defang supports generating new project outlines using integration with an AI model. Using this feature, you can describe what you would like the service to do and the CLI will then generate a project outline with all the files required to make it work.
 <iframe width="560" height="315" src="https://www.youtube.com/embed/afglsBYieuc?si=GCvHhBu3H9ktMDHA" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>

--- a/docs/tutorials/use-your-own-domain-name.mdx
+++ b/docs/tutorials/use-your-own-domain-name.mdx
@@ -10,7 +10,7 @@ In our latest version of [Defang BYOC](https://docs.defang.io/docs/concepts/defa
 <iframe width="560" height="315" src="https://www.youtube.com/embed/n4RlMpsdTbs?si=_Ru6tobSbi9LT4Q1" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
 
 
-## Step 1 : Check your [Defang BYOC](../concepts/defang-byoc.md) settings
+## Step 1 - Check your [Defang BYOC](../concepts/defang-byoc.md) settings
 
 * Make sure you [install the latest version of the Defang CLI](../getting-started/installing.md)
 * Then, make sure you have properly [authenticated your AWS account](https://docs.aws.amazon.com/cli/latest/userguide/cli-chap-configure.html). The Defang CLI makes use of AWS environment variables like `AWS_PROFILE`, `AWS_REGION`, `AWS_ACCESS_KEY_ID`, and `AWS_SECRET_ACCESS_KEY`, so make sure the correct values are set for those.
@@ -21,7 +21,7 @@ aws sts get-caller-identity
 ```
 
 
-## Step 2: Setup a Hosted Zone in AWS Route 53
+## Step 2 - Setup a Hosted Zone in AWS Route 53
 
 :::info
 **If you purchased your domain with AWS, you can skip this step.**
@@ -32,7 +32,7 @@ For Defang to be able to manage your domain, you need to create a [public hosted
 <img src="/img/domains-tutorial/zone.png" alt="Hosted Zone UI Screenshot" style={{maxWidth: 650}} />
 
 
-## Step 3: Configure your DNS settings in your domain registrar
+## Step 3 - Configure your DNS settings in your domain registrar
 
 :::info
 **If you purchased your domain with AWS, you can skip this step.**
@@ -43,7 +43,7 @@ You'll need to create NS records in your domain registrar that point to the AWS 
 ![CloudFlare NS Records Screenshot](/img/domains-tutorial/ns-records.png)
 
 
-## Step 4: Set up Your Compose File
+## Step 4 - Set up Your Compose File
 In your compose file, specify the domain name you want to use, for example
 
 ```yaml
@@ -59,7 +59,7 @@ services:
 ```
 
 
-## Step 5: Deploy
+## Step 5 - Deploy
 Run the following command to deploy your service:
 ```bash
 defang compose up

--- a/docs/tutorials/using-codespaces-gitpod.md
+++ b/docs/tutorials/using-codespaces-gitpod.md
@@ -3,7 +3,7 @@ title: Using Codespaces and Gitpod
 sidebar_position: 700
 ---
 
-# Defang with Codespaces and GitPod
+# Defang With Codespaces and GitPod
 
 <iframe width="560" height="315" src="https://www.youtube.com/embed/71pmCfLdxTg?si=Q9YIESYEUNTBFBIy" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
 
@@ -11,24 +11,24 @@ This tutorial will guide you to set up Defang in both Codespaces and Gitpod.
 
 ## Getting Started with Github Codespaces and Defang
 
-### Step 1: Clone the Defang Codespace Project
+### Step 1 - Clone the Defang Codespace Project
 Start by cloning the [Defang Github-Codespace](https://github.com/DefangLabs/github-codespace) repo and pushing it to your own account. This repository is configured with a Codespace that has Defang pre-installed.
 
 
-### Step 2: Create a Codespace
+### Step 2 - Create a Codespace
 Once you've pushed to your own GitHub repo, you'll be able to create a Codespace by clicking the Code button, selecting the Codespaces tab, and clicking the + icon. This will set up a development environment with Defang already installed, which might take a few minutes.
 
 ![Create Codespace button screenshot](/img/codespace-tutorial/new-codespace.png)
 
 
-### Step 3: Open in VS Code Desktop
+### Step 3 - Open in VS Code Desktop
 For the `defang login` command to work correctly, you must open the Codespace in VS Code desktop. This is required because the login process is designed to run on localhost.
 
 
 ![Open in vs code desktop button screenshot](/img/codespace-tutorial/desktop.png)
 
 
-### Step 4: Run Defang Login
+### Step 4 - Run Defang Login
 Within a VS Code desktop terminal, execute the following command.
 ```bash
 defang login
@@ -36,22 +36,22 @@ defang login
 Although it may initially refuse to connect on your localhost, going back will show a "successfully logged in" message, confirming that you're logged into Defang.
 
 
-### Step 5: Verify Running Services
+### Step 5 - Verify Running Services
 Now that you're logged in, you can use Defang commands. You can test that everything is working properly by running `defang ls` to list your running services.
 
 
 ## Getting Started with GitPod Workspace with Defang
 
-### Step 1: Clone the Defang GitPod Workspace Project
+### Step 1 - Clone the Defang GitPod Workspace Project
 Start by cloning the [Defang Gitpod-Workspace](https://github.com/DefangLabs/gitpod-workspace) repo and pushing it to your own GitHub, GitLab, or BitBucket account. This repository includes a Workspace configuration that pre-installs Defang.
 
 
-### Step 2: Initialize GitPod Workspace
+### Step 2 - Initialize GitPod Workspace
 Navigate `https://gitpod.io/#<your-repo-url>` to create your new workspace.
 In the repository, we have a yaml file indicating that we are using a pre-built dockerfile which installs Defang CLI for you.
 
 
-### Step 3: Lauch VS Code from GitPod
+### Step 3 - Lauch VS Code from GitPod
 Open VS Code from GitPod, you will likely need to have the GitPod VS Code extension installed.
 
 ![Open in vs code desktop button screenshot](/img/codespace-tutorial/gitpod-desktop.png)
@@ -59,7 +59,7 @@ Open VS Code from GitPod, you will likely need to have the GitPod VS Code extens
 ![Screenshot of GitPod extension](/img/codespace-tutorial/gitpod-ext.png)
 
 
-### Step 4: Run Defang Login
+### Step 4 - Run Defang Login
 Within a VS Code desktop terminal, execute the following command.
 
 ```bash
@@ -67,5 +67,5 @@ defang login
 ```
 
 
-### Step 5: Verify Running Services
+### Step 5 - Verify Running Services
 Now that you're logged in, you can use Defang commands. You can test that everything is working properly by running `defang ls` to list your running services.

--- a/docs/use-cases/_category_.json
+++ b/docs/use-cases/_category_.json
@@ -1,9 +1,8 @@
 {
   "label": "Use Cases",
-  "position": 275,
+  "position": 500,
   "link": {
     "type": "doc",
     "id": "use-cases"
   }
 }
-

--- a/docs/use-cases/use-cases.md
+++ b/docs/use-cases/use-cases.md
@@ -34,11 +34,10 @@ Some applications are designed to run in stateful environments. For example, a C
 
 ## Data Stores
 
-Defang now offers support for stateful workloads through our [managed storage](./concepts/managed-storage) options, including [Postgres](./concepts/managed-storage/managed-postgres) and [Redis](./concepts/managed-storage/managed-redis) for data stores.
-However, we do not recommend using unsupported data stores with Defang, as this may lead to permanent data loss. 
+Defang now offers support for stateful workloads through our [managed storage](./concepts/managed-storage) options, including [Postgres](./concepts/managed-storage/managed-postgres) and [Redis](./concepts/managed-storage/managed-redis) for data stores. However, we do not recommend using unsupported data stores with Defang, as this may lead to permanent data loss. 
 
 :::info 
-To better serve our users, we will be introducing additional [managed storage](./concepts/managed-storage) options in the near future. 
+To better serve our users, we will be introducing additional managed storage options, such as [Object Storage](concepts/managed-storage/managed-object-storage), in the near future. 
 :::
 
-Please be aware that if you choose not to use a Defang-supported managed service, there is a risk that any data stored in a container may be lost if the container is replaced.
+Please be aware that if you choose not to use a Defang-supported [managed storage](./concepts/managed-storage) option, there is a risk that any data stored in a container may be lost if the container is replaced.

--- a/docs/use-cases/use-cases.md
+++ b/docs/use-cases/use-cases.md
@@ -26,7 +26,7 @@ LLMs (Large Language Models) are a type of AI model that can be used for a wide 
 
 # Anti-patterns
 
-While Defang is great for a wide variety of use cases, there are some use cases that are not a good fit for Defang. Generally, the use-cases that are Defang anti-patterns are the same as the ones that are [12 Factor](https://12factor.net/) anti-patterns. Here are some examples:
+While Defang is great for a wide variety of use cases, there are some use cases that are not a good fit for Defang. Generally, the use-cases that are Defang anti-patterns are the same as the ones that are [12 Factor](https://12factor.net/) anti-patterns. 
 
 ## Stateful Services
 
@@ -34,10 +34,11 @@ Some applications are designed to run in stateful environments. For example, a C
 
 ## Data Stores
 
-While Defang is primarily designed for stateless workloads, Defang now offers support for stateful workloads through our [managed storage](./concepts/managed-storage) options, including [Postgres](./concepts/managed-storage/managed-postgres) and [Redis](./concepts/managed-storage/managed-redis). 
+Defang now offers support for stateful workloads through our [managed storage](./concepts/managed-storage) options, including [Postgres](./concepts/managed-storage/managed-postgres) and [Redis](./concepts/managed-storage/managed-redis) for data stores.
+However, we do not recommend using unsupported data stores with Defang, as this may lead to permanent data loss. 
 
-:::warning
-Using unsupported data stores (e.g., ElasticSearch) with Defang is strongly discouraged. Doing so may result in permanent data loss. Stick to Defang's managed services like [Postgres](./concepts/managed-storage/managed-postgres) and [Redis](./concepts/managed-storage/managed-redis) for reliable data persistence.
+:::info 
+To better serve our users, we will be introducing additional [managed storage](./concepts/managed-storage) options in the near future. 
 :::
 
 Please be aware that if you choose not to use a Defang-supported managed service, there is a risk that any data stored in a container may be lost if the container is replaced.

--- a/docs/use-cases/use-cases.md
+++ b/docs/use-cases/use-cases.md
@@ -34,4 +34,6 @@ Some applications are designed to run in stateful environments. For example, a C
 
 ## Data Stores
 
-Defang is not a good fit for data stores like databases, caches, and message queues. These types of services are designed to be long-lived and to store data. Defang is primarily designed for stateless workloads, and it's not a good fit for stateful workloads: if a container is replaced, all the data in it is lost. You could probably coerce a data store to work in a stateless environment with certain replication strategies, but it's not a good fit.
+Defang now offers paid tier support for managed services for databases and caches, including [Postgres](./concepts/managed-storage/managed-postgres) and [Redis](./concepts/managed-storage/managed-redis). While Defang is primarily designed for stateless workloads, it can now support stateful workloads (persistent data storage) if used with one of the mentioned managed services above. 
+
+Please be aware that if you choose not to use a managed service, there is a risk that any data stored in a container may be lost if the container is replaced.

--- a/docs/use-cases/use-cases.md
+++ b/docs/use-cases/use-cases.md
@@ -34,10 +34,10 @@ Some applications are designed to run in stateful environments. For example, a C
 
 ## Data Stores
 
-Defang now offers paid tier support for managed [Postgres](./concepts/managed-storage/managed-postgres) and [Redis](./concepts/managed-storage/managed-redis) data store services. While Defang is primarily designed for stateless workloads, it can now support stateful workloads if used with one of the managed services mentioned above. 
+While Defang is primarily designed for stateless workloads, Defang now offers support for stateful workloads through our [managed storage](./concepts/managed-storage) options, including [Postgres](./concepts/managed-storage/managed-postgres) and [Redis](./concepts/managed-storage/managed-redis). 
 
 :::warning
-Using unsupported data stores (e.g., ElasticSearch) with Defang is strongly discouraged. Doing so may result in permanent data loss. Stick to Defang's managed services like Postgres and Redis for reliable data persistence.
+Using unsupported data stores (e.g., ElasticSearch) with Defang is strongly discouraged. Doing so may result in permanent data loss. Stick to Defang's managed services like [Postgres](./concepts/managed-storage/managed-postgres) and [Redis](./concepts/managed-storage/managed-redis) for reliable data persistence.
 :::
 
 Please be aware that if you choose not to use a Defang-supported managed service, there is a risk that any data stored in a container may be lost if the container is replaced.

--- a/docs/use-cases/use-cases.md
+++ b/docs/use-cases/use-cases.md
@@ -34,6 +34,10 @@ Some applications are designed to run in stateful environments. For example, a C
 
 ## Data Stores
 
-Defang now offers paid tier support for managed services for databases and caches, including [Postgres](./concepts/managed-storage/managed-postgres) and [Redis](./concepts/managed-storage/managed-redis). While Defang is primarily designed for stateless workloads, it can now support stateful workloads (persistent data storage) if used with one of the mentioned managed services above. 
+Defang now offers paid tier support for managed [Postgres](./concepts/managed-storage/managed-postgres) and [Redis](./concepts/managed-storage/managed-redis) data store services. While Defang is primarily designed for stateless workloads, it can now support stateful workloads if used with one of the managed services mentioned above. 
 
-Please be aware that if you choose not to use a managed service, there is a risk that any data stored in a container may be lost if the container is replaced.
+:::warning
+Using unsupported data stores (e.g., ElasticSearch) with Defang is strongly discouraged. Doing so may result in permanent data loss. Stick to Defang's managed services like Postgres and Redis for reliable data persistence.
+:::
+
+Please be aware that if you choose not to use a Defang-supported managed service, there is a risk that any data stored in a container may be lost if the container is replaced.

--- a/docs/use-cases/use-cases.md
+++ b/docs/use-cases/use-cases.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 100
+sidebar_position: 400
 title: Use Cases
 description: Use cases for Defang.
 ---

--- a/docs/use-cases/use-cases.md
+++ b/docs/use-cases/use-cases.md
@@ -10,7 +10,7 @@ Defang can be used for a wide variety of use cases, generally in line with the [
 
 ## Web Services and APIs
 
-Defang can be used to deploy web services and APIs. You can use any programming language you like, and you can use the built-in AI assistant to help you get started.
+Defang can be used to deploy web services and APIs. You can use any programming language you like, and you can use the built-in AI agent to help you get started.
 
 Defang is a great choice for stateless web services and APIs because it takes care of all the heavy lifting such as configuring [networking](../concepts/networking.mdx), [security](../concepts/security.md), and [observability](../concepts/observability.md), and will give you a nice, [horizontally scalable](https://12factor.net/concurrency) deployment.
 


### PR DESCRIPTION
Changes in this PR

- [x] Create a "Deploy to your own cloud" tutorial
  - [x] Create a "Deploy to your own AWS Account" tutorial
  - [x] Create a "Deploy to your own Digital Ocean Account" tutorial
  - [x] Create a stub for "Deploy to your own GCP Account"
- [x] After getting started, "Deploy to your own cloud" is the next recommended tutorial
- [x] Document Deployment modes
  - [ ] create a "rolling updates" concept page
  - [ ] create a "databases" concept page
- [x] Add a few more items to the FAQ
- [x] Add more linkable subheadings to the AWS and Digital Ocean Provider pages
