### PR TITLE
Fix "Digital Ocean" naming in blogs

### DIFF
--- a/blog/2024-08-30-august-product-updates.md
+++ b/blog/2024-08-30-august-product-updates.md
@@ -6,7 +6,7 @@ tags:
     Cloud,
     NoDevOps,
     BYOC,
-    Digital Ocean,
+    DigitalOcean,
     CLI,
     AI,
     Debugging,
@@ -64,7 +64,7 @@ Register here!
 We're working on a number of new features to make Defang even better. Here are some of the most exciting ones:
 
 - **Managed Postgres**: We're working on getting Defang to provision managed Postgres services for you, so you can easily store and query data in your applications.
-- **Digital Ocean BYOC**: We're working on adding Digital Ocean BYOC to give you even more choice over where you deploy your applications.
+- **DigitalOcean BYOC**: We're working on adding DigitalOcean BYOC to give you even more choice over where you deploy your applications.
 
 ---
 

--- a/blog/2024-09-30-september-product-updates.md
+++ b/blog/2024-09-30-september-product-updates.md
@@ -7,7 +7,7 @@ tags:
     NoDevOps,
     BYOC,
     Postgres,
-    Digital Ocean,
+    DigitalOcean,
     CLI,
     AI,
     Debugging,

--- a/blog/2024-11-13-october-product-updates.md
+++ b/blog/2024-11-13-october-product-updates.md
@@ -7,7 +7,7 @@ tags:
     NoDevOps,
     BYOC,
     Postgres,
-    Digital Ocean,
+    DigitalOcean,
     AWS,
     CLI,
     AI,

--- a/docs/providers/digitalocean/_category_.json
+++ b/docs/providers/digitalocean/_category_.json
@@ -1,5 +1,5 @@
 {
-  "label": "Digital Ocean",
+  "label": "DigitalOcean",
   "position": 2000,
   "collapsible": true
 }


### PR DESCRIPTION
In blog tags, revised all occurrences of the space in "Digital Ocean" so it shows "DigitalOcean" 