### PR TITLE
More documentation revisions

### DIFF
--- a/docs/concepts/deployment-modes.md
+++ b/docs/concepts/deployment-modes.md
@@ -1,5 +1,5 @@
 ---
-title: Defang Deployment Modes
+title: Deployment Modes
 description: Defang provides three deployment modes which allow you to balance cost and resiliency.
 sidebar_position: 501
 ---

--- a/docs/tutorials/deploy-with-gpu.mdx
+++ b/docs/tutorials/deploy-with-gpu.mdx
@@ -7,9 +7,17 @@ sidebar_position: 500
 
 This tutorial guides you to create and deploy a GPU-powered application on AWS using Defang and Mistral. We will walk you through the whole deployment process based on this [Deploying Mistral with vLLM](https://github.com/DefangLabs/samples/tree/main/samples/vllm) sample.
 
+:::info
+Note that GPU deployments are not permitted on the Defang Playground. You must [upgrade to a paid account](https://defang.io/pricing/) and [deploy to your own cloud account](https://docs.defang.io/docs/tutorials/deploy-to-your-cloud).
+:::
+
 <iframe width="560" height="315" src="https://www.youtube.com/embed/kynFa2zU7hQ?si=qdV0xa6vkhMFJ6qv" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
 
 ## Prerequisites
+
+* [A Defang Account](/docs/concepts/authentication)
+* [The Defang CLI](/docs/getting-started#install-the-defang-cli)
+* [AWS Account Credentials](https://docs.aws.amazon.com/cli/latest/userguide/cli-chap-authentication.html)
 
 ### AWS Account with GPU Access
 

--- a/docs/tutorials/deploy-with-gpu.mdx
+++ b/docs/tutorials/deploy-with-gpu.mdx
@@ -3,7 +3,7 @@ title: Deploy a GPU-Powered Application
 sidebar_position: 500
 ---
 
-# Deploy a GPU-Powered Application
+# Deploy a GPU-Powered Application to AWS
 
 This tutorial guides you to create and deploy a GPU-powered application on AWS using Defang and Mistral. We will walk you through the whole deployment process based on this [Deploying Mistral with vLLM](https://github.com/DefangLabs/samples/tree/main/samples/vllm) sample.
 

--- a/docs/tutorials/monitoring-your-services.md
+++ b/docs/tutorials/monitoring-your-services.md
@@ -6,19 +6,43 @@ description: How to monitoring services deployed with Defang
 
 # Monitoring Your Services
 
-Monitoring your services with Defang.
-By default, all the output (stdout and stderr) from your app is logged. You can view these logs in real-time. You can view logs for all your services, one service, or even one specific deployment of a service.
+## Status
 
-- From the CLI:
+When deploying to Playground, you can monitor your service status from the [Defang Portal](https://portal.defang.dev).
 
-    ```tsx
-    defang tail --name service1
-    ```
+When deploying to your own cloud, the primary way to monitor your services is through your cloud provider's dashboard. Defang does, however, provide some tools for monitoring your service logs.
 
-- From the Defang Portal:
+## Logs
 
-    [https://portal.defang.dev/](https://portal.defang.dev/)
+When deploying to Playground, your service's logs may be viewed in the [Defang Portal](https://portal.defang.dev).
 
+By default, all the output (stdout and stderr) from your app is logged. You can view these logs in real-time or for a time in the past. You can view logs for all your services, one service, or even one specific deployment of a service.
+
+### Tailing Live Logs For All Services
+
+```bash
+$ defang tail
+```
+
+### Tailing Logs Since a Specific Time
+
+```bash
+$ defang tail --since 1h
+```
+
+### Tailing Logs For a Service
+
+```bash
+$ defang tail --name service-name
+```
+
+### Build Time Logs
+
+```bash
+$ defang logs --type=build
+```
+
+All of the above flags can be combined to get the exact logs you need. See the CLI reference for [`defang tail`](/docs/cli/defang_tail) for more information.
 
 :::info
 * To learn more about observability in Defang, check out the [observability page](../concepts/observability.md).

--- a/docs/tutorials/updating-your-services.md
+++ b/docs/tutorials/updating-your-services.md
@@ -6,8 +6,28 @@ description: How to update services deployed with Defang
 
 # Updating Your Services
 
-To update your app (for example, updating the base image of your container, or making changes to your code) you can run the `defang compose up` command and it will build and deploy a new version with zero downtime. Your current version of the service will keep running and handling traffic while the new version is being built and deployed. Only after the new version passes the health checks and accepts traffic will the older version be stopped.
+To update your app (for example, updating the base image of your container, or making changes to your code) all you have to do is run the `defang compose up` command and it will build and deploy a new version.
+
+## Deploying New Services or Removing Existing Services
+
+If you are using [compose files](../concepts/compose.md) to define your services, you can add/remove services, make changes to code, etc. When you run `defang compose up`, the update will be diffed against the current state and any necessary changes will be applied to make the current state match the desired state.
+
+## Deployment Modes
+
+Defang offers multiple [deployment modes](/docs/concepts/deployment-modes). You can specify which mode you would like to be used when you deploy with the `--mode` flag on the CLI. The default mode is `development`. You may also specify `staging` or `production`.
+
+```shell
+$ defang compose up --mode=production
+```
+
+### Development Mode (Default)
+
+The default deployment mode is `development`. This is the In this mode, the existing services will be deprovisioned before your new service will be spun up. This means that there will be a short downtime while the new service is being provisioned.
+
+### Production Mode (Zero-downtime Updates)
+
+If you are running in `production` mode, the update will be done with zero downtime. Your current version of the service will keep running and handling traffic while the new version is being built and deployed. Only after the new version passes the health checks and accepts traffic will the older version be stopped.
 
 :::info
-If you are using [compose files](../concepts/compose.md) to define your services, you can add/remove services, make changes to code, etc. When you run `defang compose up`, the update will be diffed against the current state and any necessary changes will be applied to make the current state match the desired state.
+For more information on Deployment Modes, see the [Deployment Modes](/docs/concepts/deployment-modes) concept documentation.
 :::

--- a/docs/tutorials/use-your-own-domain-name.mdx
+++ b/docs/tutorials/use-your-own-domain-name.mdx
@@ -3,25 +3,17 @@ title: How to Use Your Own Domain
 sidebar_position: 600
 ---
 
-# How to Use Your Own Domain
-
-In our latest version of [Defang BYOC](https://docs.defang.io/docs/concepts/defang-byoc) (Bring Your Own Cloud), you can now use your own domain name. (Currently, this new feature is not applicable to [Defang Playground](https://docs.defang.io/docs/concepts/defang-playground))
+# How to Use Your Own Domain with AWS
 
 <iframe width="560" height="315" src="https://www.youtube.com/embed/n4RlMpsdTbs?si=_Ru6tobSbi9LT4Q1" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
 
+## Prerequisites
 
-## Step 1 - Check your [Defang BYOC](../concepts/defang-byoc.md) settings
+* [A Defang Account](/docs/concepts/authentication)
+* [The Defang CLI](/docs/getting-started#install-the-defang-cli)
+* [AWS Account Credentials](https://docs.aws.amazon.com/cli/latest/userguide/cli-chap-authentication.html)
 
-* Make sure you [install the latest version of the Defang CLI](../getting-started#install-the-defang-cli.md)
-* Then, make sure you have properly [authenticated your AWS account](https://docs.aws.amazon.com/cli/latest/userguide/cli-chap-configure.html). The Defang CLI makes use of AWS environment variables like `AWS_PROFILE`, `AWS_REGION`, `AWS_ACCESS_KEY_ID`, and `AWS_SECRET_ACCESS_KEY`, so make sure the correct values are set for those.
-
-If you use the AWS CLI, you can verify that your are authenticated against AWS using the following command (note that the AWS CLI itself is not required to use the Defang CLI in BYOC mode):
-```bash
-aws sts get-caller-identity
-```
-
-
-## Step 2 - Setup a Hosted Zone in AWS Route 53
+## Step 1 - Setup a Hosted Zone in AWS Route 53
 
 :::info
 **If you purchased your domain with AWS, you can skip this step.**
@@ -31,8 +23,7 @@ For Defang to be able to manage your domain, you need to create a [public hosted
 
 <img src="/img/domains-tutorial/zone.png" alt="Hosted Zone UI Screenshot" style={{maxWidth: 650}} />
 
-
-## Step 3 - Configure your DNS settings in your domain registrar
+## Step 2 - Configure your DNS settings in your domain registrar
 
 :::info
 **If you purchased your domain with AWS, you can skip this step.**
@@ -43,7 +34,7 @@ You'll need to create NS records in your domain registrar that point to the AWS 
 ![CloudFlare NS Records Screenshot](/img/domains-tutorial/ns-records.png)
 
 
-## Step 4 - Set up Your Compose File
+## Step 3 - Set up Your Compose File
 In your compose file, specify the domain name you want to use, for example
 
 ```yaml
@@ -59,7 +50,7 @@ services:
 ```
 
 
-## Step 5 - Deploy
+## Step 4 - Deploy
 Run the following command to deploy your service:
 ```bash
 defang compose up
@@ -68,3 +59,7 @@ defang compose up
 This will deploy your service and set up the necessary DNS records in Route 53 as seen in the screenshot below as well as provision SSL certificates. You can now access your service at the domain you specified in your compose file.
 
 <img src="/img/domains-tutorial/route53-records.png" alt="Route 53 DNS Records Screenshot" />
+
+***
+
+For a deeper discussion of how to use a custom domain with Defang, see our [Domain](/docs/concepts/domains) concept docs.


### PR DESCRIPTION
Changes in this PR
* [x] less wordy sidebar title for domains tutorial
* [x] Add clarification regarding deployment modes to "Updating Services" tutorial
* [x] Add more examples about how to view various slices of service logs
* [x] Clarifying a few things in BYOD and GPU docs:
  * [x] Clarify that the current docs are for AWS. We still need to document these features for DO and GCP
  * [x] Note that GPUs are not permitted on playground
  * [x] Remove note that BYOD is forbidden on playground
  * [x] Add "prerequisite" section to GPU and BYOD tutorials for consistency with other tutorials
