### PR TITLE
Make the Provider pages consistent for cloud providers

### DIFF
--- a/docs/providers/digitalocean/digitalocean.md
+++ b/docs/providers/digitalocean/digitalocean.md
@@ -39,8 +39,7 @@ The Defang CLI will automatically check if these envinonment variables are set b
 
 ### Deploy your project to DigitalOcean
 
-Once you are ready to go, add the `--provider=digitalocean` to your command to tell the Defang CLI to use the DigitalOcean provider.
-
+Once you are ready to go, add the `--provider=digitalocean` to your command to tell the Defang CLI to use the DigitalOcean provider or set the `DEFANG_PROVIDER` environment variable to `digitalocean`.
 ```bash
 $ defang compose up --provider=digitalocean
 # or

--- a/docs/providers/gcp.md
+++ b/docs/providers/gcp.md
@@ -27,12 +27,12 @@ gcloud init
 gcloud auth application-default login
 ```
 
-The Defang CLI will automatically check if `GCP_PROJECT_ID` environment variable is set and correctly authenticated with GCP before running. Once you are ready to go, add the `--provider=gcp` to your command to tell the Defang CLI to use the GCP provider.
+The Defang CLI will automatically check if `GCP_PROJECT_ID` environment variable is set and correctly authenticated with GCP before running. Once you are ready to go, add the `--provider=gcp` flag to your command to tell the Defang CLI to use the GCP provider, or set the `DEFANG_PROVIDER` environment variable to `gcp`.
 
 ```bash
-$ defang up --provider=gcp
+$ defang compose up --provider=gcp
 # or
-$ DEFANG_PROVIDER=gcp defang up
+$ export DEFANG_PROVIDER=gcp
 ```
 
 ## Location

--- a/docs/tutorials/deploy-to-gcp.mdx
+++ b/docs/tutorials/deploy-to-gcp.mdx
@@ -27,12 +27,12 @@ After signing in to your GCP account, select an existing project or [create a ne
 
 ## Step 3 - Deploy
 
-Invoke the `defang up` CLI command with the `--provider=gcp` flag or set the `DEFANG_PROVIDER=gcp` environment variable.
+Invoke the `defang compose up` CLI command with the `--provider=gcp` flag or set the `DEFANG_PROVIDER=gcp` environment variable.
 
 For example:
 
 ```bash
-$ defang up --provider=gcp
+$ defang compose up --provider=gcp
 ```
 
 ## Step 4 - Inspect your deployment


### PR DESCRIPTION
- make the instructions use `defang compose up` consistently
- Make the example of the env var/provider flag for DigitalOcean/GCP match the other clouds