### PR TITLE
remove version property from yaml file

### DIFF
--- a/docs/tutorials/deploy-container-using-the-cli.mdx
+++ b/docs/tutorials/deploy-container-using-the-cli.mdx
@@ -19,7 +19,6 @@ If you already have a Docker Compose file to define your service(s), you can use
 
 
 ```yaml
-version: '3.9'
 services:
   web:
     image: nginx:latest
@@ -50,4 +49,3 @@ Run the following command in the [Defang CLI](/docs/getting-started#install-the-
 defang compose up
 ```
     
-


### PR DESCRIPTION
Remove `version: '3.9'` from compose file, as it is now an obsolete property. 