### PR TITLE
Remove Townhall/Coffee Chat to avoid outdated info for Ask Defang

### DIFF
--- a/blog/2024-08-30-august-product-updates.md
+++ b/blog/2024-08-30-august-product-updates.md
@@ -49,14 +49,6 @@ Looking ahead, we’re excited to collaborate with [MLH](https://mlh.io/), [Hack
 
 <img src="/img/august-update/townhall.png" alt="TownHall" style={{ width: 300 }} />
 
-## Townhall
-
-Mark your calendars! If you’re eager to learn more about what’s coming next, join us for our Townhall on September 25th. We’ll be sharing our future roadmap, answering your questions, and gathering your feedback.
-
-<Button href="https://lu.ma/9d8irae8" variant="contained" size="large" target="_blank">
-Register here!
-</Button>
-
 ---
 
 ## Roadmap

--- a/blog/2024-09-30-september-product-updates.md
+++ b/blog/2024-09-30-september-product-updates.md
@@ -45,18 +45,8 @@ Also in Sep, Defang was included in the [Google for Startups Accelerator Canada.
 
 ---
 
-<img src="/img/september-update/coffee-chat.png" alt="TownHall" style={{ width: 300 }} />
-
-## Defang Coffee Chat
-
-Mark your calendars! If you’re eager to learn more about what’s coming next, join us for our Defang Coffee Chat on Oct 23rd 2024.
-We’ll be sharing our future roadmap, answering your questions, and gathering your feedback.
-
-<Button href="https://lu.ma/hlnq84xq" variant="contained" size="large" target="_blank">
-Register here!
-</Button>
+<img src="/img/september-update/coffee-chat.png" alt="CoffeeChat" style={{ width: 300 }} />
 
 ---
 
 As always, we appreciate your feedback and are committed to making Defang the easiest way to develop, deploy, and debug your cloud applications. Go build something awesome! 🚀
-

--- a/blog/2024-12-04-launch-week.md
+++ b/blog/2024-12-04-launch-week.md
@@ -67,7 +67,7 @@ Join us during [MLH Global Hack Week](https://ghw.mlh.io/schedule) for hands-on 
 
 - **December 7: Cloud Chat**
 
-An IRL event with our team to explore V1 features in depth, answer your questions, and share insights from our journey. Register [here](https://lu.ma/cloudchat) to join. 
+An IRL event with our team to explore V1 features in depth, answer your questions, and share insights from our journey.
 
 - **December 10: Product Hunt Launch**
 


### PR DESCRIPTION
Ask Defang chatbot relies on the data in the latest build of the docs. To avoid outdated information being resurfaced in the chatbot, I removed the descriptive sections for Townhall and Coffee Chat in older blogs. 