### PR TITLE
update scaling documents, mention replicas should not be defined

### DIFF
--- a/docs/concepts/scaling.md
+++ b/docs/concepts/scaling.md
@@ -37,7 +37,11 @@ Instead of manually adding more instances when traffic increases, an auto-scalin
 
 ### Example
 
-With Defang a user, with a Pro and higher plan, can enable service level autoscaling by adding a _**x-defang-autoscaling**_ extension to the service which is to be autoscaled.
+With Defang, users on the Pro plan or higher can enable service-level autoscaling in three steps:
+
+1. Add the _**x-defang-autoscaling : true**_ extension to the service you want to autoscale.
+2. Removing any _**replicas**_ field in the _**deploy**_ mapping (if present).
+3. Deploy using staging or production [mode](/docs/concepts/deployments#deployment-modes). (e.g. ```defang compose up --provider=aws --mode=production```)
 
 ```yaml
 services:

--- a/docs/tutorials/scaling-your-services.mdx
+++ b/docs/tutorials/scaling-your-services.mdx
@@ -66,7 +66,8 @@ Autoscaling allows your services to automatically adjust the number of replicas 
 
 ### Enabling Autoscaling
 
-To enable autoscaling for a service, add the `x-defang-autoscaling: true` extension under the service definition in your `compose.yaml` file.
+To enable autoscaling for a service, add the `x-defang-autoscaling: true` extension under the service definition in your `compose.yaml` file and remove the _**replicas**_ field in your
+_**deploy**_ mapping, if present. Autoscaling is available in staging and production [deployments modes](/docs/concepts/deployments#deployment_modes) only.
 
 Example:
 
@@ -85,9 +86,9 @@ Requirements
 
 - BYOC, your own cloud platform account.
 - You must be on the Pro or higher plan to use autoscaling. ([Defang plans](https://defang.io/#pricing))
+- _**replicas**_ must **NOT** be defined
 - Only staging and production deployment modes supported. ([Deployment modes](/docs/concepts/deployment-modes))
 - The service must be stateless or able to run in multiple instances. ([Scaling](/docs/concepts/scaling))
-- Only CPU metrics are used for scaling decisions.
 
 Best Practices
 


### PR DESCRIPTION
Update scaling documents to mention replicas should not be defined.