### PR TITLE
Show all blog posts + other md formatting fixes

### DIFF
--- a/docs/concepts/defang-byoc.md
+++ b/docs/concepts/defang-byoc.md
@@ -31,7 +31,7 @@ $ export DEFANG_PROVIDER=digitalocean
 
 Please read the [AWS Provider](../providers/aws/aws.md) documentation for more details about how the AWS provider works and how to get started.
 
-:::success AWS Free Tier & Credits
+:::tip[AWS Free Tier & Credits]
 You can use the AWS Free Tier to try out Defang. Learn more about it [here](https://aws.amazon.com/free/?all-free-tier.sort-by=item.additionalFields.SortRank&all-free-tier.sort-order=asc&awsf.Free%20Tier%20Types=*all&awsf.Free%20Tier%20Categories=*all). If you're an elligible startup, you can sign up for credits [here](https://aws.amazon.com/startups/sign-up?referrer_url_path=%2Fstartups).
 :::
 
@@ -44,7 +44,7 @@ The Defang DigitalOcean Provider is available for Public Preview as of October 2
 
 Please read the [DigitalOcean Provider](../providers/digitalocean/digitalocean.md) documentation for more details about how the DigitalOcean provider works and how to get started.
 
-:::success DigitalOcean Credits
+:::tip[DigitalOcean Credits]
 You can get DigitalOcean credits to try out Defang. Learn more about it on their [pricing page](https://www.digitalocean.com/pricing). If you're an elligible startup, you can sign up for credits [here](https://www.digitalocean.com/hatch).
 :::
 
@@ -56,10 +56,9 @@ The Defang GCP Provider is available for Public Preview as of December 2024.
 
 Please check out the [GCP Provider](../providers/gcp/) page for more details.
 
-:::success GCP Free Tier & Credits
+:::tip[GCP Free Tier & Credits]
 You can use the GCP Free Tier to try out Defang. Learn more about it [here](https://cloud.google.com/free). If you're an elligible startup, you can sign up for credits [here](https://cloud.google.com/developers/startups).
 :::
-
 
 ## Azure
 

--- a/docs/concepts/defang-byoc.md
+++ b/docs/concepts/defang-byoc.md
@@ -32,7 +32,7 @@ $ export DEFANG_PROVIDER=digitalocean
 Please read the [AWS Provider](../providers/aws/aws.md) documentation for more details about how the AWS provider works and how to get started.
 
 :::tip[AWS Free Tier & Credits]
-You can use the AWS Free Tier to try out Defang. Learn more about it [here](https://aws.amazon.com/free/?all-free-tier.sort-by=item.additionalFields.SortRank&all-free-tier.sort-order=asc&awsf.Free%20Tier%20Types=*all&awsf.Free%20Tier%20Categories=*all). If you're an elligible startup, you can sign up for credits [here](https://aws.amazon.com/startups/sign-up?referrer_url_path=%2Fstartups).
+You can use the AWS Free Tier to try out Defang. Learn more about it [here](https://aws.amazon.com/free/?all-free-tier.sort-by=item.additionalFields.SortRank&all-free-tier.sort-order=asc&awsf.Free%20Tier%20Types=*all&awsf.Free%20Tier%20Categories=*all). If you're an eligible startup, you can sign up for credits [here](https://aws.amazon.com/startups/sign-up?referrer_url_path=%2Fstartups).
 :::
 
 ## DigitalOcean
@@ -45,7 +45,7 @@ The Defang DigitalOcean Provider is available for Public Preview as of October 2
 Please read the [DigitalOcean Provider](../providers/digitalocean/digitalocean.md) documentation for more details about how the DigitalOcean provider works and how to get started.
 
 :::tip[DigitalOcean Credits]
-You can get DigitalOcean credits to try out Defang. Learn more about it on their [pricing page](https://www.digitalocean.com/pricing). If you're an elligible startup, you can sign up for credits [here](https://www.digitalocean.com/hatch).
+You can get DigitalOcean credits to try out Defang. Learn more about it on their [pricing page](https://www.digitalocean.com/pricing). If you're an eligible startup, you can sign up for credits [here](https://www.digitalocean.com/hatch).
 :::
 
 ## GCP
@@ -57,7 +57,7 @@ The Defang GCP Provider is available for Public Preview as of December 2024.
 Please check out the [GCP Provider](../providers/gcp/) page for more details.
 
 :::tip[GCP Free Tier & Credits]
-You can use the GCP Free Tier to try out Defang. Learn more about it [here](https://cloud.google.com/free). If you're an elligible startup, you can sign up for credits [here](https://cloud.google.com/developers/startups).
+You can use the GCP Free Tier to try out Defang. Learn more about it [here](https://cloud.google.com/free). If you're an eligible startup, you can sign up for credits [here](https://cloud.google.com/developers/startups).
 :::
 
 ## Azure

--- a/docs/concepts/managed-storage/managed-object-storage.md
+++ b/docs/concepts/managed-storage/managed-object-storage.md
@@ -6,7 +6,7 @@ sidebar_position: 3000
 
 # Managed Object Storage
 
-:::info Not Yet Supported
+:::info[Not Yet Supported]
 As of September 2024, Defang does not yet support managed Object Storage, but it is on our roadmap. If you are interested in Object Storage support, please vote on [this issue](https://github.com/DefangLabs/defang/issues/688).
 :::
 

--- a/docs/concepts/managed-storage/managed-postgres.mdx
+++ b/docs/concepts/managed-storage/managed-postgres.mdx
@@ -10,12 +10,12 @@ Postgres, or PostgreSQL, is a powerful open-source relational database system kn
 
 ## Current Support
 
-| Provider                                                         | Managed Postgres |
-| ---------------------------------------------------------------- | ---------------- |
-| [Playground](/docs/providers/playground#managed-services)        | ❌               |
-| [AWS](/docs/providers/aws#managed-storage)                       | ✅               |
-| [DigitalOcean](/docs/providers/digitalocean#future-improvements) | ❌               |
-| [GCP](/docs/providers/gcp#future-improvements)                   | ✅               |
+| Provider | Managed Postgres |
+| --- | --- |
+| [Playground](/docs/providers/playground#managed-services) | ❌ |
+| [AWS](/docs/providers/aws#managed-storage) | ✅ |
+| [DigitalOcean](/docs/providers/digitalocean#future-improvements) | ❌ |
+| [GCP](/docs/providers/gcp#future-improvements) | ✅ |
 
 ## How to use Managed Postgres
 

--- a/docs/concepts/managed-storage/managed-postgres.mdx
+++ b/docs/concepts/managed-storage/managed-postgres.mdx
@@ -10,12 +10,12 @@ Postgres, or PostgreSQL, is a powerful open-source relational database system kn
 
 ## Current Support
 
-| Provider | Managed Postgres |
-| --- | --- |
-| [Playground](/docs/providers/playground#managed-services) | ❌ |
-| [AWS](/docs/providers/aws#managed-storage) | ✅ |
-| [DigitalOcean](/docs/providers/digitalocean#future-improvements) | ❌ |
-| [GCP](/docs/providers/gcp#future-improvements) | ✅ |
+| Provider                                                         | Managed Postgres |
+| ---------------------------------------------------------------- | ---------------- |
+| [Playground](/docs/providers/playground#managed-services)        | ❌               |
+| [AWS](/docs/providers/aws#managed-storage)                       | ✅               |
+| [DigitalOcean](/docs/providers/digitalocean#future-improvements) | ❌               |
+| [GCP](/docs/providers/gcp#future-improvements)                   | ✅               |
 
 ## How to use Managed Postgres
 
@@ -39,6 +39,7 @@ You can also set the following optional environment variables to configure the m
 You can connect to the managed Postgres instance using the name of your service as the hostname, `POSTGRES_USER`, `POSTGRES_DB`, and `POSTGRES_PASSWORD` environment variables.
 
 ### Example
+
 :::info
 For a smoother experience with Defang, we recommend using Postgres 14 for your container images. This version provides easier access and improved usability.
 :::
@@ -83,7 +84,7 @@ When a project is deployed to a [production environment](/docs/concepts/deployme
 
 The AWS Console can be used to restore a snapshot into a new instance of Postgres.
 
-<!-- 
+{/* 
 ### Major Version Updating of Engine
 
 To update the database engine you can update the image to a later version in your Compose file and apply it via ```defang compose up --provider=aws```. In the example below, we change from Postgres 15 to 16.
@@ -100,4 +101,5 @@ to
 ```
 database:
   image: postgres:16
-``` -->
+``` 
+ */}

--- a/docs/concepts/managed-storage/managed-storage.md
+++ b/docs/concepts/managed-storage/managed-storage.md
@@ -6,5 +6,4 @@ sidebar_position: 000
 
 # Managed Storage
 
-Defang helps you provision the infrastructure you need to run your services. That infrastructure is designed to scale in and out without persistent storage, so you can build highly scalable services. But Defang can also help you provision managed services to store and persist your data, like [caches](./managed-redis.md), [databases](./managed-postgres.md), and [object storage](./managed-object-storage.md).
-
+Defang helps you provision the infrastructure you need to run your services. That infrastructure is designed to scale in and out without persistent storage, so you can build highly scalable services. But Defang can also help you provision managed services to store and persist your data, like [caches](./managed-redis.md), [databases](./managed-postgres.mdx), and [object storage](./managed-object-storage.md).

--- a/docs/concepts/resources.md
+++ b/docs/concepts/resources.md
@@ -19,7 +19,7 @@ services:
       replicas: 3
       resources:
         reservations:
-          cpus: '1.0'
+          cpus: "1.0"
           memory: 2048M
           devices:
             - capabilities: ["gpu"]
@@ -32,17 +32,17 @@ const service = new defang.DefangService("gpu-service", {
   deploy: {
     replicas: 3,
     resources: {
-        reservations: {
-            cpu: 1.0,
-            memory: 2048,
-            devices: [{capabilities: ['gpu']}]
-        }
-    }
-  }
+      reservations: {
+        cpu: 1.0,
+        memory: 2048,
+        devices: [{ capabilities: ["gpu"] }],
+      },
+    },
+  },
 });
 ```
 
-:::info GPUs
+:::info[GPUs]
 If you require access to GPUs, you can specify this in the `deploy.resources.reservations.devices[0].capabilities` section of your service as in the examples above. You can learn more about this in the [Docker-Compose documentation](https://docs.docker.com/compose/gpu-support/). This is the only supported value in the `deploy.resources.reservations.devices` section.
 :::
 
@@ -68,7 +68,7 @@ Defang uses `shm_size` to configure both the memory and disk space available to 
 The default `shm_size` values for each platform are as follows. More or less may be specified.
 
 | Platform      | `shm_size` Minimum |
-|---------------|--------------------|
+| ------------- | ------------------ |
 | AWS           | 16G                |
 | Digital Ocean | 8G                 |
 | GCP           | 16G                |

--- a/docs/providers/aws/aws.md
+++ b/docs/providers/aws/aws.md
@@ -82,51 +82,51 @@ When using [Managed LLMs](/docs/concepts/managed-llms/managed-language-models.md
 
 Defang will create and manage the following resources in your AWS account from its bootstrap CloudFormation template:
 
-| Resource Type                           | Example Resource Name                                                                     |
-| --------------------------------------- | ----------------------------------------------------------------------------------------- | -------------------- |
-| s3/Bucket                               | defang-cd-bucket-cbpbzz8hzm7                                                              |
-| ecs/ClusterCapacityProviderAssociations | defang-cd-Cluster-pqFhjwuklvm                                                             |
-| ecs/Cluster                             | defang-cd-ClusterpJqFhjwuklvm                                                             |
-| iam/Role                                | defang-cd-ExeutionRole-XE7RbQDfeEwx                                                       |
-| ec2/InternetGateway                     | igw-05bd7adc92541ec3                                                                      |
-| ec2/VPCGatewayAttachment                | IGW                                                                                       | vpc-0cbca64f13435695 |
-| logs/LogGroup                           | defang-cd-Logroup-6LSZet3tFnEy                                                            |
-| ecr/PullThroughCacheRule                | defang-cd-ecrpublic                                                                       |
-| ec2/Route                               | rtb-08f3f5afc9e6c8c8                                                                      | 0.0.0.0/0            |
-| ec2/RouteTable                          | rtb-08f3f5ffc9e6c8c8                                                                      |
-| ec2/VPCEndpoint                         | vpce-02175d8d4f47d0c9                                                                     |
-| ec2/SecurityGroup                       | sg-032b839c63e70e49                                                                       |
-| ec2/Subnet                              | subnet-086bead399ddc8a0                                                                   |
-| ec2/SubnetRouteTableAssociation         | rtbassoc-02e200d45e7227fe                                                                 |
-| ecs/TaskDefinition                      | arn:aws:ecsus-west-2:381492210770:task-definition/defang-cd-TaskDefinition-RXd5tf9TaN38:1 |
-| iam/Role                                | defang-cd-askRole-gsEeDPd6sPQY                                                            |
-| ec2/VPC                                 | vpc-0cbca64f13435695                                                                      |
+| Resource Type | Example Resource Name |
+|---------------|------------------------|
+| s3/Bucket | defang-cd-bucket-cbpbzz8hzm7  |
+| ecs/ClusterCapacityProviderAssociations | defang-cd-Cluster-pqFhjwuklvm |
+| ecs/Cluster | defang-cd-ClusterpJqFhjwuklvm  |
+| iam/Role | defang-cd-ExeutionRole-XE7RbQDfeEwx  |
+| ec2/InternetGateway | igw-05bd7adc92541ec3  |
+| ec2/VPCGatewayAttachment | IGW|vpc-0cbca64f13435695 |
+| logs/LogGroup | defang-cd-Logroup-6LSZet3tFnEy  |
+| ecr/PullThroughCacheRule | defang-cd-ecrpublic |
+| ec2/Route | rtb-08f3f5afc9e6c8c8|0.0.0.0/0 |
+| ec2/RouteTable | rtb-08f3f5ffc9e6c8c8 |
+| ec2/VPCEndpoint | vpce-02175d8d4f47d0c9  |
+| ec2/SecurityGroup | sg-032b839c63e70e49  |
+| ec2/Subnet | subnet-086bead399ddc8a0  |
+| ec2/SubnetRouteTableAssociation | rtbassoc-02e200d45e7227fe |
+| ecs/TaskDefinition | arn:aws:ecsus-west-2:381492210770:task-definition/defang-cd-TaskDefinition-RXd5tf9TaN38:1 |
+| iam/Role | defang-cd-askRole-gsEeDPd6sPQY  |
+| ec2/VPC | vpc-0cbca64f13435695  |
 
 Then, for each project you deploy, Defang will create and manage the following resources:
 
-| Resource Type                 | Example Resource Name                    |
-| ----------------------------- | ---------------------------------------- |
-| ecr/Repository                | project1/kaniko-build                    |
-| ecr/LifecyclePolicy           | project1/kaniko-build                    |
-| acm/Certificate               | \*.project1.tenant1.defang.app           |
-| ecr/Repository                | project1/kaniko-build/cache              |
-| ecr/LifecyclePolicy           | project1/kaniko-build/cache              |
-| iam/InstanceProfile           | ecs-agent-profile                        |
-| iam/Role                      | ecs-task-execution-role                  |
-| cloudwatch/EventRule          | project1-ecs-lifecycle-rule              |
-| cloudwatch/EventTarget        | project1-ecs-event-cw-target             |
-| route53/Record                | validation-project1.tenant1.defang.app   |
-| acm/CertificateValidation     | \*.project1.tenant1.defang.appValidation |
-| ec2/VpcDhcpOptionsAssociation | dhcp-options-association                 |
-| cloudwatch/LogGroup           | builds                                   |
-| iam/Role                      | kaniko-task-role                         |
-| ecs/TaskDefinition            | kanikoTaskDefArm64                       |
-| ecs/TaskDefinition            | kanikoTaskDefAmd64                       |
-| s3/Bucket                     | defang-build                             |
-| s3/BucketPublicAccessBlock    | defang-build-block                       |
-| ecs/Cluster                   | cluster                                  |
-| ecs/ClusterCapacityProviders  | cluster-capacity-providers               |
-| ec2/SecurityGroup             | project1_app-sg                          |
-| ec2/SecurityGroup             | bootstrap                                |
-| ec2/VpcDhcpOptions            | dhcp-options                             |
-| cloudwatch/LogGroup           | logs                                     |
+| Resource Type | Example Resource Name |
+|---------------|------------------------|
+| ecr/Repository | project1/kaniko-build |
+| ecr/LifecyclePolicy | project1/kaniko-build |
+| acm/Certificate | *.project1.tenant1.defang.app |
+| ecr/Repository | project1/kaniko-build/cache |
+| ecr/LifecyclePolicy | project1/kaniko-build/cache |
+| iam/InstanceProfile | ecs-agent-profile |
+| iam/Role | ecs-task-execution-role |
+| cloudwatch/EventRule | project1-ecs-lifecycle-rule |
+| cloudwatch/EventTarget | project1-ecs-event-cw-target |
+| route53/Record | validation-project1.tenant1.defang.app |
+| acm/CertificateValidation | *.project1.tenant1.defang.appValidation |
+| ec2/VpcDhcpOptionsAssociation | dhcp-options-association |
+| cloudwatch/LogGroup | builds |
+| iam/Role | kaniko-task-role |
+| ecs/TaskDefinition | kanikoTaskDefArm64 |
+| ecs/TaskDefinition | kanikoTaskDefAmd64 |
+| s3/Bucket | defang-build |
+| s3/BucketPublicAccessBlock | defang-build-block |
+| ecs/Cluster | cluster |
+| ecs/ClusterCapacityProviders | cluster-capacity-providers |
+| ec2/SecurityGroup | project1_app-sg |
+| ec2/SecurityGroup | bootstrap |
+| ec2/VpcDhcpOptions | dhcp-options |
+| cloudwatch/LogGroup | logs |

--- a/docs/providers/aws/aws.md
+++ b/docs/providers/aws/aws.md
@@ -8,7 +8,7 @@ sidebar_position: 000
 
 Why should you use Defang with AWS? Defang allows you to easily create and manage full, scalable applications with AWS. Defang aims to make it easier to deploy your services to the cloud. Don't waste your time learning the ins and outs of AWS, deciding which of the 200+ services to use, and then writing the infrastructure code to deploy your services, and making sure they are properly secured. Defang does all of that for you.
 
-:::success AWS Free Tier & Credits
+:::tip[AWS Free Tier & Credits]
 You can use the AWS Free Tier to try out Defang. Learn more about it [here](https://aws.amazon.com/free/?all-free-tier.sort-by=item.additionalFields.SortRank&all-free-tier.sort-order=asc&awsf.Free%20Tier%20Types=*all&awsf.Free%20Tier%20Categories=*all). If you're an elligible startup, you can sign up for credits [here](https://aws.amazon.com/startups/sign-up?referrer_url_path=%2Fstartups).
 :::
 

--- a/docs/providers/aws/aws.md
+++ b/docs/providers/aws/aws.md
@@ -9,7 +9,7 @@ sidebar_position: 000
 Why should you use Defang with AWS? Defang allows you to easily create and manage full, scalable applications with AWS. Defang aims to make it easier to deploy your services to the cloud. Don't waste your time learning the ins and outs of AWS, deciding which of the 200+ services to use, and then writing the infrastructure code to deploy your services, and making sure they are properly secured. Defang does all of that for you.
 
 :::tip[AWS Free Tier & Credits]
-You can use the AWS Free Tier to try out Defang. Learn more about it [here](https://aws.amazon.com/free/?all-free-tier.sort-by=item.additionalFields.SortRank&all-free-tier.sort-order=asc&awsf.Free%20Tier%20Types=*all&awsf.Free%20Tier%20Categories=*all). If you're an elligible startup, you can sign up for credits [here](https://aws.amazon.com/startups/sign-up?referrer_url_path=%2Fstartups).
+You can use the AWS Free Tier to try out Defang. Learn more about it [here](https://aws.amazon.com/free/?all-free-tier.sort-by=item.additionalFields.SortRank&all-free-tier.sort-order=asc&awsf.Free%20Tier%20Types=*all&awsf.Free%20Tier%20Categories=*all). If you're an eligible startup, you can sign up for credits [here](https://aws.amazon.com/startups/sign-up?referrer_url_path=%2Fstartups).
 :::
 
 ## Getting Started

--- a/docs/providers/aws/aws.md
+++ b/docs/providers/aws/aws.md
@@ -66,7 +66,7 @@ Defang can help you provision [managed storage](/docs/concepts/managed-storage/m
 
 ### Managed Postgres
 
-When using [Managed Postgres](/docs/concepts/managed-storage/managed-postgres.md), the Defang CLI provisions an RDS Postgres instance in your account.
+When using [Managed Postgres](/docs/concepts/managed-storage/managed-postgres.mdx), the Defang CLI provisions an RDS Postgres instance in your account.
 
 ### Managed Redis
 
@@ -82,51 +82,51 @@ When using [Managed LLMs](/docs/concepts/managed-llms/managed-language-models.md
 
 Defang will create and manage the following resources in your AWS account from its bootstrap CloudFormation template:
 
-| Resource Type | Example Resource Name |
-|---------------|------------------------|
-| s3/Bucket | defang-cd-bucket-cbpbzz8hzm7  |
-| ecs/ClusterCapacityProviderAssociations | defang-cd-Cluster-pqFhjwuklvm |
-| ecs/Cluster | defang-cd-ClusterpJqFhjwuklvm  |
-| iam/Role | defang-cd-ExeutionRole-XE7RbQDfeEwx  |
-| ec2/InternetGateway | igw-05bd7adc92541ec3  |
-| ec2/VPCGatewayAttachment | IGW|vpc-0cbca64f13435695 |
-| logs/LogGroup | defang-cd-Logroup-6LSZet3tFnEy  |
-| ecr/PullThroughCacheRule | defang-cd-ecrpublic |
-| ec2/Route | rtb-08f3f5afc9e6c8c8|0.0.0.0/0 |
-| ec2/RouteTable | rtb-08f3f5ffc9e6c8c8 |
-| ec2/VPCEndpoint | vpce-02175d8d4f47d0c9  |
-| ec2/SecurityGroup | sg-032b839c63e70e49  |
-| ec2/Subnet | subnet-086bead399ddc8a0  |
-| ec2/SubnetRouteTableAssociation | rtbassoc-02e200d45e7227fe |
-| ecs/TaskDefinition | arn:aws:ecsus-west-2:381492210770:task-definition/defang-cd-TaskDefinition-RXd5tf9TaN38:1 |
-| iam/Role | defang-cd-askRole-gsEeDPd6sPQY  |
-| ec2/VPC | vpc-0cbca64f13435695  |
+| Resource Type                           | Example Resource Name                                                                     |
+| --------------------------------------- | ----------------------------------------------------------------------------------------- | -------------------- |
+| s3/Bucket                               | defang-cd-bucket-cbpbzz8hzm7                                                              |
+| ecs/ClusterCapacityProviderAssociations | defang-cd-Cluster-pqFhjwuklvm                                                             |
+| ecs/Cluster                             | defang-cd-ClusterpJqFhjwuklvm                                                             |
+| iam/Role                                | defang-cd-ExeutionRole-XE7RbQDfeEwx                                                       |
+| ec2/InternetGateway                     | igw-05bd7adc92541ec3                                                                      |
+| ec2/VPCGatewayAttachment                | IGW                                                                                       | vpc-0cbca64f13435695 |
+| logs/LogGroup                           | defang-cd-Logroup-6LSZet3tFnEy                                                            |
+| ecr/PullThroughCacheRule                | defang-cd-ecrpublic                                                                       |
+| ec2/Route                               | rtb-08f3f5afc9e6c8c8                                                                      | 0.0.0.0/0            |
+| ec2/RouteTable                          | rtb-08f3f5ffc9e6c8c8                                                                      |
+| ec2/VPCEndpoint                         | vpce-02175d8d4f47d0c9                                                                     |
+| ec2/SecurityGroup                       | sg-032b839c63e70e49                                                                       |
+| ec2/Subnet                              | subnet-086bead399ddc8a0                                                                   |
+| ec2/SubnetRouteTableAssociation         | rtbassoc-02e200d45e7227fe                                                                 |
+| ecs/TaskDefinition                      | arn:aws:ecsus-west-2:381492210770:task-definition/defang-cd-TaskDefinition-RXd5tf9TaN38:1 |
+| iam/Role                                | defang-cd-askRole-gsEeDPd6sPQY                                                            |
+| ec2/VPC                                 | vpc-0cbca64f13435695                                                                      |
 
 Then, for each project you deploy, Defang will create and manage the following resources:
 
-| Resource Type | Example Resource Name |
-|---------------|------------------------|
-| ecr/Repository | project1/kaniko-build |
-| ecr/LifecyclePolicy | project1/kaniko-build |
-| acm/Certificate | *.project1.tenant1.defang.app |
-| ecr/Repository | project1/kaniko-build/cache |
-| ecr/LifecyclePolicy | project1/kaniko-build/cache |
-| iam/InstanceProfile | ecs-agent-profile |
-| iam/Role | ecs-task-execution-role |
-| cloudwatch/EventRule | project1-ecs-lifecycle-rule |
-| cloudwatch/EventTarget | project1-ecs-event-cw-target |
-| route53/Record | validation-project1.tenant1.defang.app |
-| acm/CertificateValidation | *.project1.tenant1.defang.appValidation |
-| ec2/VpcDhcpOptionsAssociation | dhcp-options-association |
-| cloudwatch/LogGroup | builds |
-| iam/Role | kaniko-task-role |
-| ecs/TaskDefinition | kanikoTaskDefArm64 |
-| ecs/TaskDefinition | kanikoTaskDefAmd64 |
-| s3/Bucket | defang-build |
-| s3/BucketPublicAccessBlock | defang-build-block |
-| ecs/Cluster | cluster |
-| ecs/ClusterCapacityProviders | cluster-capacity-providers |
-| ec2/SecurityGroup | project1_app-sg |
-| ec2/SecurityGroup | bootstrap |
-| ec2/VpcDhcpOptions | dhcp-options |
-| cloudwatch/LogGroup | logs |
+| Resource Type                 | Example Resource Name                    |
+| ----------------------------- | ---------------------------------------- |
+| ecr/Repository                | project1/kaniko-build                    |
+| ecr/LifecyclePolicy           | project1/kaniko-build                    |
+| acm/Certificate               | \*.project1.tenant1.defang.app           |
+| ecr/Repository                | project1/kaniko-build/cache              |
+| ecr/LifecyclePolicy           | project1/kaniko-build/cache              |
+| iam/InstanceProfile           | ecs-agent-profile                        |
+| iam/Role                      | ecs-task-execution-role                  |
+| cloudwatch/EventRule          | project1-ecs-lifecycle-rule              |
+| cloudwatch/EventTarget        | project1-ecs-event-cw-target             |
+| route53/Record                | validation-project1.tenant1.defang.app   |
+| acm/CertificateValidation     | \*.project1.tenant1.defang.appValidation |
+| ec2/VpcDhcpOptionsAssociation | dhcp-options-association                 |
+| cloudwatch/LogGroup           | builds                                   |
+| iam/Role                      | kaniko-task-role                         |
+| ecs/TaskDefinition            | kanikoTaskDefArm64                       |
+| ecs/TaskDefinition            | kanikoTaskDefAmd64                       |
+| s3/Bucket                     | defang-build                             |
+| s3/BucketPublicAccessBlock    | defang-build-block                       |
+| ecs/Cluster                   | cluster                                  |
+| ecs/ClusterCapacityProviders  | cluster-capacity-providers               |
+| ec2/SecurityGroup             | project1_app-sg                          |
+| ec2/SecurityGroup             | bootstrap                                |
+| ec2/VpcDhcpOptions            | dhcp-options                             |
+| cloudwatch/LogGroup           | logs                                     |

--- a/docs/providers/digitalocean/digitalocean.md
+++ b/docs/providers/digitalocean/digitalocean.md
@@ -80,7 +80,7 @@ The following features are still in development for DigitalOcean:
 
 - [Custom Domains](/docs/concepts//domains.mdx)
 - [Managed Redis](/docs/concepts//managed-storage/managed-redis.md)
-- [Managed Postgres](/docs/concepts/managed-storage/managed-postgres.md)
+- [Managed Postgres](/docs/concepts/managed-storage/managed-postgres.mdx)
 - [Managed Language Models](/docs/concepts/managed-llms/managed-language-models.md)
 
 Stay tuned for future updates!

--- a/docs/providers/digitalocean/digitalocean.md
+++ b/docs/providers/digitalocean/digitalocean.md
@@ -10,7 +10,7 @@ sidebar_position: 010
 The Defang DigitalOcean Provider is available for Public Preview as of October 2024.
 :::
 
-:::success DigitalOcean Credits
+:::tip[DigitalOcean Credits]
 You can get DigitalOcean credits to try out Defang. Learn more about it on their [pricing page](https://www.digitalocean.com/pricing). If you're an elligible startup, you can sign up for credits [here](https://www.digitalocean.com/hatch).
 :::
 
@@ -23,12 +23,15 @@ Why should you use Defang with DigitalOcean? Defang allows you to easily create 
 To get started with the Defang BYOC DigitalOcean Provider, first [install the latest version of the Defang CLI](../getting-started#authenticate-with-defang).
 
 ### Sign up for DigitalOcean
+
 Next, make sure you have signed up for a [DigitalOcean account](https://try.digitalocean.com/freetrialoffer/).
 
 ### Authenticate with DigitalOcean
+
 After signing up for your account, be sure to set up your [personal access token](https://docs.digitalocean.com/reference/api/create-personal-access-token/). Defang will need to find this value in your shell as the `DIGITALOCEAN_TOKEN` environment variable.
 
 ### Authenticate with DigitalOcean Spaces
+
 You will also need a [DigitalOcean Spaces access key](https://docs.digitalocean.com/products/spaces/how-to/manage-access/). Defang will need to find this value in your shell as the `SPACES_ACCESS_KEY_ID`, and `SPACES_SECRET_ACCESS_KEY` environment variables.
 
 ### Configure your shell environment
@@ -44,6 +47,7 @@ The Defang CLI will automatically check if these envinonment variables are set b
 ### Deploy your project to DigitalOcean
 
 Once you are ready to go, add the `--provider=digitalocean` to your command to tell the Defang CLI to use the DigitalOcean provider or set the `DEFANG_PROVIDER` environment variable to `digitalocean`.
+
 ```bash
 $ defang compose up --provider=digitalocean
 # or
@@ -73,6 +77,7 @@ Defang allows you to configure your services with [sensitive config values](http
 ### Future Improvements
 
 The following features are still in development for DigitalOcean:
+
 - [Custom Domains](/docs/concepts//domains.mdx)
 - [Managed Redis](/docs/concepts//managed-storage/managed-redis.md)
 - [Managed Postgres](/docs/concepts/managed-storage/managed-postgres.md)

--- a/docs/providers/digitalocean/digitalocean.md
+++ b/docs/providers/digitalocean/digitalocean.md
@@ -11,7 +11,7 @@ The Defang DigitalOcean Provider is available for Public Preview as of October 2
 :::
 
 :::tip[DigitalOcean Credits]
-You can get DigitalOcean credits to try out Defang. Learn more about it on their [pricing page](https://www.digitalocean.com/pricing). If you're an elligible startup, you can sign up for credits [here](https://www.digitalocean.com/hatch).
+You can get DigitalOcean credits to try out Defang. Learn more about it on their [pricing page](https://www.digitalocean.com/pricing). If you're an eligible startup, you can sign up for credits [here](https://www.digitalocean.com/hatch).
 :::
 
 Why should you use Defang with DigitalOcean? Defang allows you to easily create and manage full, scalable applications with DigitalOcean. Defang aims to make it easier to deploy your services to the cloud. DigitalOcean is one of the most popular cloud providers in the world and with Defang, you can bypass the complexities of the DigitalOcean platform. Let Defang do it for you and spend more time working on what's important to you!

--- a/docs/providers/gcp.md
+++ b/docs/providers/gcp.md
@@ -10,7 +10,7 @@ sidebar_position: 3000
 The Defang GCP Provider is available for Public Preview as of December 2024.
 :::
 
-:::success GCP Free Tier & Credits
+:::tip[GCP Free Tier & Credits]
 You can use the GCP Free Tier to try out Defang. Learn more about it [here](https://cloud.google.com/free). If you're an elligible startup, you can sign up for credits [here](https://cloud.google.com/developers/startups).
 :::
 
@@ -66,6 +66,7 @@ Defang offers integration with managed, cloud-native large language model servic
 ### Future Improvements
 
 The following features are in active development for GCP:
+
 - [Configuration and management of secrets](/docs/concepts//configuration.md)
 - [Networking and Load Balancing](/docs/concepts//networking.mdx)
 - [Custom Domains](/docs/concepts//domains.mdx)

--- a/docs/providers/gcp.md
+++ b/docs/providers/gcp.md
@@ -11,7 +11,7 @@ The Defang GCP Provider is available for Public Preview as of December 2024.
 :::
 
 :::tip[GCP Free Tier & Credits]
-You can use the GCP Free Tier to try out Defang. Learn more about it [here](https://cloud.google.com/free). If you're an elligible startup, you can sign up for credits [here](https://cloud.google.com/developers/startups).
+You can use the GCP Free Tier to try out Defang. Learn more about it [here](https://cloud.google.com/free). If you're an eligible startup, you can sign up for credits [here](https://cloud.google.com/developers/startups).
 :::
 
 Defang enables you to effortlessly develop and deploy full, scalable applications with GCP. It is designed to simplify deploying your services to the cloud. As one of the leading cloud providers globally, GCP offers powerful tools and resources, and with Defang, you can bypass the complexities of the GCP platform. Let Defang handle the heavy lifting so you can focus on what matters most to you!

--- a/docs/providers/gcp.md
+++ b/docs/providers/gcp.md
@@ -71,6 +71,6 @@ The following features are in active development for GCP:
 - [Networking and Load Balancing](/docs/concepts//networking.mdx)
 - [Custom Domains](/docs/concepts//domains.mdx)
 - [Managed Redis](/docs/concepts//managed-storage/managed-redis.md)
-- [Managed Postgres](/docs/concepts/managed-storage/managed-postgres.md)
+- [Managed Postgres](/docs/concepts/managed-storage/managed-postgres.mdx)
 
 Stayed tuned for future updates!

--- a/docs/tutorials/deploy-with-gpu.mdx
+++ b/docs/tutorials/deploy-with-gpu.mdx
@@ -5,7 +5,7 @@ sidebar_position: 500
 
 # Deploy a GPU-Powered Application to AWS
 
-This tutorial will show you how to create and deploy a GPU-powered application on AWS using Defang. 
+This tutorial will show you how to create and deploy a GPU-powered application on AWS using Defang.
 
 We will walk you through the whole deployment process based on the [Mistral & vLLM](https://github.com/DefangLabs/samples/tree/main/samples/vllm) sample.
 
@@ -13,19 +13,28 @@ We will walk you through the whole deployment process based on the [Mistral & vL
 Note that GPU deployments are not permitted on the Defang Playground. You must [upgrade to a paid account](https://defang.io/pricing/) and [deploy to your own cloud account](https://docs.defang.io/docs/tutorials/deploy-to-your-cloud).
 :::
 
-<iframe width="560" height="315" src="https://www.youtube.com/embed/kynFa2zU7hQ?si=qdV0xa6vkhMFJ6qv" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
+<iframe
+  width="560"
+  height="315"
+  src="https://www.youtube.com/embed/kynFa2zU7hQ?si=qdV0xa6vkhMFJ6qv"
+  title="YouTube video player"
+  frameborder="0"
+  allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
+  referrerpolicy="strict-origin-when-cross-origin"
+  allowfullscreen
+></iframe>
 
 ## Prerequisites
 
-* [A Defang Account](/docs/concepts/authentication)
-* [The Defang CLI](/docs/getting-started#install-the-defang-cli)
-* [AWS Account Credentials](https://docs.aws.amazon.com/cli/latest/userguide/cli-chap-authentication.html)
+- [A Defang Account](/docs/concepts/authentication)
+- [The Defang CLI](/docs/getting-started#install-the-defang-cli)
+- [AWS Account Credentials](https://docs.aws.amazon.com/cli/latest/userguide/cli-chap-authentication.html)
 
 ### AWS Account with GPU Access
 
 For any of this to work, you'll need to have access to GPU instances in your AWS account. To do that you'll need to go to the "[Service Quotas](https://console.aws.amazon.com/servicequotas/home)" console in your AWS account. From there you can request access to spot GPU instances. You'll need to request 8 or more because the value is per vCPU and the smallest GPU instance has 8 vCPUs. The instance types you're requesting are "All G and VT spot instances".
 
-:::warning Timing
+:::warning[Timing]
 This process can take a few days for AWS to approve.
 :::
 
@@ -41,26 +50,28 @@ You'll need to clone the [Mistral & vLLM](https://github.com/DefangLabs/samples/
 
 ## Step 2 - Check your [Defang BYOC](../concepts/defang-byoc.md) settings
 
-* Make sure you [install the latest version of the Defang CLI](../getting-started#install-the-defang-cli.md)
-* Then, make sure you have properly [authenticated your AWS account](https://docs.aws.amazon.com/cli/latest/userguide/cli-chap-configure.html). The Defang CLI makes use of AWS environment variables like `AWS_PROFILE`, `AWS_REGION`, `AWS_ACCESS_KEY_ID`, and `AWS_SECRET_ACCESS_KEY`, so make sure the correct values are set for those.
+- Make sure you [install the latest version of the Defang CLI](../getting-started#install-the-defang-cli.md)
+- Then, make sure you have properly [authenticated your AWS account](https://docs.aws.amazon.com/cli/latest/userguide/cli-chap-configure.html). The Defang CLI makes use of AWS environment variables like `AWS_PROFILE`, `AWS_REGION`, `AWS_ACCESS_KEY_ID`, and `AWS_SECRET_ACCESS_KEY`, so make sure the correct values are set for those.
 
 :::tip
 If you have the AWS CLI installed (which is not required in order to use the Defang CLI), you can verify that you've authenticated to AWS by running `aws sts get-caller-identity` and see your account ID.
 :::
 
 ## Step 3 - Prepare your Environment
-* Log into your Defang account
+
+- Log into your Defang account
+
 ```bash
 defang login
 ```
 
-* Set the HuggingFace token using the `defang config` command
+- Set the HuggingFace token using the `defang config` command
+
 ```bash
 defang config set --name HF_TOKEN
 ```
 
 [Configuration](../concepts/configuration.md) stores your sensitive information such as API keys, passwords, and other credentials for you.
-
 
 ## Step 4 - Explore the Compose File
 
@@ -105,19 +116,19 @@ We start with the latest vLLM Docker image provided by [Mistral AI](https://docs
 
 ```yaml
 mistral:
-    image: ghcr.io/mistralai/mistral-src/vllm:latest
+  image: ghcr.io/mistralai/mistral-src/vllm:latest
 ```
 
 We specify that we require a GPU to run our application.
 
 ```yaml
 deploy:
-    resources:
-        reservations:
+  resources:
+    reservations:
             cpus: '2.0'
-            memory: 8192M
-            devices:
-                - capabilities: ["gpu"]
+      memory: 8192M
+      devices:
+        - capabilities: ["gpu"]
 ```
 
 The Mistral model will be downloaded from HuggingFace. We need to have a HuggingFace Token to enable the installation, so we specify that we need to get the `HF_TOKEN` configuration value from Defang.
@@ -126,40 +137,39 @@ Specifying the `HF_TOKEN` in the `environment` section of the service in the `co
 
 ```yaml
 environment:
-    - HF_TOKEN
+  - HF_TOKEN
 ```
 
 ### The UI Service
 
 In this sample we also provide a simple UI to interact with the endpoint created by vLLM. The UI service is a Next.js application that runs on port 3000.
 
-:::tip Networking
+:::tip
 You can see here how Defang's [networking](../concepts//networking.mdx) works. The `mistral` service is available at `http://mistral:8000`, exactly as it would be in a local `docker-compose` environment.
 :::
 
 ```yaml
-  ui:
-    restart: unless-stopped
-    build:
-      context: ui
-      dockerfile: Dockerfile
-    ports:
-      - mode: ingress
-        target: 3000
-    deploy:
-      resources:
-        reservations:
-          memory: 256M
-    healthcheck:
-      test: ["CMD","wget","--spider","http://localhost:3000"]
-      interval: 10s
-      timeout: 2s
-      retries: 10
+ui:
+  restart: unless-stopped
+  build:
+    context: ui
+    dockerfile: Dockerfile
+  ports:
+    - mode: ingress
+      target: 3000
+  deploy:
+    resources:
+      reservations:
+        memory: 256M
+  healthcheck:
+    test: ["CMD", "wget", "--spider", "http://localhost:3000"]
+    interval: 10s
+    timeout: 2s
+    retries: 10
     environment:
       // highlight-next-line
-      - OPENAI_BASE_URL=http://mistral:8000/v1/
+    - OPENAI_BASE_URL=http://mistral:8000/v1/
 ```
-
 
 ## Step 5 - Deploy to Your Own AWS Account with Defang
 

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -192,9 +192,9 @@ const config = {
     mermaid: true,
     format: 'mdx',
     mdx1Compat: { //Values are set to true to enable features for Docusaurus v3+
-      comments: true, 
-      admonitions: true,
-      headingIds: true
+      comments: false, 
+      admonitions: false,
+      headingIds: false
     }
   },
 };

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -68,6 +68,8 @@ const config = {
             'https://github.com/DefangLabs/defang-docs/tree/main/',
         },
         blog: {
+          blogSidebarCount: 'ALL', // Show all posts in sidebar
+          blogSidebarTitle: 'All Posts', // Custom title
           showReadingTime: true,
           // Remove the editUrl property for the blog section
         },

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -192,7 +192,7 @@ const config = {
     mermaid: true,
     format: 'mdx',
     mdx1Compat: {
-      comments: false,
+      comments: true,
       admonitions: false,
       headingIds: false
     }

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -191,7 +191,7 @@ const config = {
   markdown: {
     mermaid: true,
     format: 'mdx',
-    mdx1Compat: { //Set to true to enable features for Docusaurus v3+
+    mdx1Compat: { //Values are set to true to enable features for Docusaurus v3+
       comments: true, 
       admonitions: true,
       headingIds: true

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -191,10 +191,10 @@ const config = {
   markdown: {
     mermaid: true,
     format: 'mdx',
-    mdx1Compat: {
-      comments: true,
-      admonitions: false,
-      headingIds: false
+    mdx1Compat: { //Set to true to enable features for Docusaurus v3+
+      comments: true, 
+      admonitions: true,
+      headingIds: true
     }
   },
 };

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -188,6 +188,12 @@ const config = {
   ],
   markdown: {
     mermaid: true,
+    format: 'mdx',
+    mdx1Compat: {
+      comments: false,
+      admonitions: false,
+      headingIds: false
+    }
   },
 };
 

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -191,7 +191,7 @@ const config = {
   markdown: {
     mermaid: true,
     format: 'mdx',
-    mdx1Compat: { //Values are set to true to enable features for Docusaurus v3+
+    mdx1Compat: { //set to false for Docusaurus v3+ compatibility
       comments: false, 
       admonitions: false,
       headingIds: false


### PR DESCRIPTION
- Fixes #206 and #223 

- Added the necessary field `mdx1Compat` to `markdown` in `docusaurus.config.js` file
- Updated markdown formatting to be consistent with newer Docusaurus v3+ standards
  - Custom admonitions are now styled like: `:::info[GPUs] :::`
  - Comments in markdown are now styled like `{/* comment here */}`, and are allowed in `.mdx` files only
- Fixed typo "elligible" to "eligible"
- Some minor linting fixes