### PR TITLE
Use cloud-neutral model name

### DIFF
--- a/docs/concepts/managed-llms/managed-language-models.md
+++ b/docs/concepts/managed-llms/managed-language-models.md
@@ -49,5 +49,5 @@ Defang has a [*Managed LLM sample*](https://github.com/DefangLabs/samples/tree/m
 
 
 ## Managed LLM on Playground
-If you are using the Managed LLM feature on [Defang Playground](/docs/concepts.defang-playground), please note that your `MODEL` (model ID) will be limited to `anthropic.claude-3-haiku-20240307-v1:0`.
+If you are using the Managed LLM feature on [Defang Playground](/docs/concepts.defang-playground), please note that your `MODEL` (model ID) will be limited to `ai/claude3-haiku`.
 To access a full range of models, consider using [Defang BYOC](/docs/concepts/defang-byoc).


### PR DESCRIPTION
Now that we support model mapping, and because compose files should remain cloud-neutral, we should probably reference a cloud-neutral model id in this notice.

See https://github.com/DefangLabs/openai-access-gateway/blob/main/src/data/modelmap.json#L4