### PR TITLE
Serve samples.md for docs chatbot context

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,4 +21,5 @@ yarn-error.log*
 
 defang
 samples
+/docs/samples.md
 /static/samples-v2.json

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "private": true,
   "scripts": {
     "docusaurus": "docusaurus",
+    "prestart": "./scripts/prebuild.sh",
     "start": "docusaurus start",
     "prebuild": "./scripts/prebuild.sh",
     "build": "docusaurus build",

--- a/scripts/prep-samples.js
+++ b/scripts/prep-samples.js
@@ -34,10 +34,16 @@ directories.forEach((sample) => {
     // Languages:
     //
     // We want to extract the title, short description, tags, and languages from the readme. Tags and languages are comma separated lists.
-    const title = readme.match(/Title: (.*)/)[1];
-    const shortDescription = readme.match(/Short Description: (.*)/)[1];
-    const tags = readme.match(/Tags: (.*)/)[1].split(',').map(tag => tag.trim());
-    const languages = readme.match(/Languages: (.*)/)[1].split(',').map(language => language.trim());
+    let title, shortDescription, tags, languages;
+    try {
+        title = readme.match(/Title: (.*)/)[1];
+        shortDescription = readme.match(/Short Description: (.*)/)[1];
+        tags = readme.match(/Tags: (.*)/)[1].split(',').map(tag => tag.trim());
+        languages = readme.match(/Languages: (.*)/)[1].split(',').map(language => language.trim());
+    } catch (error) {
+        console.log(`@@ Failed to parse readme for sample ${sample}`, error);
+        return;
+    }
 
     let configs = new Set();
     try {

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -138,3 +138,7 @@ img.unstyled {
     background-position: 200% 0;
   }
 }
+
+.menu__list-item.hidden {
+  display: none;
+}


### PR DESCRIPTION
This PR prepares and serves a file at `docs/samples.md` which is hidden in the navigation sidebar, but which can be used as a reference by the docs chatbot.

There are a few small changes we make to the docs as we concatenate them:
* link the first top-level header to the samples repo directory for this sample
* increase the heading level by one step for the new page (`## Configuration` -> `### Configuration`)
* remove any horizontal rules
* remove any images
