### PR TITLE
Remove blog slugs and use redirects for docs-chatbot compatibility

### DIFF
--- a/blog/2025-06-06-may-product-updates.md
+++ b/blog/2025-06-06-may-product-updates.md
@@ -1,7 +1,6 @@
 ---
 title: "May 2025 Defang Compose Update"
 description: "Monthly product updates from the Defang team - May 2025"
-slug: 2025-06-06-product-update
 tags:
   [
     Cloud,

--- a/blog/2025-06-16-crew-ai-sample.md
+++ b/blog/2025-06-16-crew-ai-sample.md
@@ -1,7 +1,6 @@
 ---
 title: "Sample: Starter Kit for RAG + Agents with CrewAI"
 description: "Going over our sample for RAG + Agents with CrewAI"
-slug: rag-agents-crewai-sample
 tags: [Cloud, NoDevOps, Docker Compose, Defang, Sample]
 author: Defang Team
 ---
@@ -89,4 +88,3 @@ DEFANG_PROVIDER=<provider> defang compose up
 ```
 
 Want more? File an [issue](https://github.com/DefangLabs/samples/issues) to request a sample—we'll do everything we can to help you deploy better and faster!
-

--- a/blog/2025-06-16-docker-compose-defang.md
+++ b/blog/2025-06-16-docker-compose-defang.md
@@ -1,7 +1,6 @@
 ---
 title: "Bridging Local Development and Cloud Deployment"
 description: "Announcing our new whitepaper: Bridging Local Development and Cloud Deployment with Docker Compose and Defang"
-slug: defang-docker-compose
 tags: [Cloud, NoDevOps, Docker Compose, Defang, Whitepaper]
 author: Defang Team
 ---

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -32,6 +32,9 @@ const redirects = [
   { from: '/blog/deploying-defang-with-defang-part-2', to: '/blog/2025/03/26/deploying-defang-with-defang-part-2' },
   { from: '/blog/website-logo-refresh-announcement', to: '/blog/2025/03/12/website-logo-refresh-announcement' },
   { from: '/blog/2025-05-09-product-update', to: '/blog/2025/05/09/april-product-updates' },
+  { from: '/blog/2025-06-06-product-update', to: '/blog/2025/06/06/may-product-updates' },
+  { from: '/blog/rag-agents-crew-ai-sample', to: '/blog/2025/06/16/crew-ai-sample' },
+  { from: '/blog/defang-docker-compose', to: '/blog/2025/06/16/docker-compose-defang' },
 ];
 
 /** @type {import('@docusaurus/types').DocusaurusConfig} */


### PR DESCRIPTION
Remove blog slugs and add redirects instead for compatibility with docs-chatbot link parsing. 

Currently, if you add a custom slug to a blog, the docs-chatbot (i.e. [Ask Defang](https://ask.defang.io/)) will provide an incorrect link to that blog in its list of references because the link is auto-generated based on the file name. For example, if the file name in the repo is `2025-06-16-crew-ai-sample.md` , the docs-chatbot will generate the link using the formula that changes dates to slashes and uses the exact file name, such as `2025/06/16-crew-ai-sample`. If you use a slug such as `rag-agents-crew-ai-sample`, then the docs-chatbot will not be able to point to that link ending because it only knows the auto-generated link. 

I would suggest using redirects in the `docusaurus.config.js` file to redirect a user to a particular link as an alternative to slugs for better compatibility with the chatbot in its current state. 