### PR TITLE
gcloud CLI typo

### DIFF
--- a/docs/tutorials/deploy-to-gcp.mdx
+++ b/docs/tutorials/deploy-to-gcp.mdx
@@ -13,7 +13,7 @@ This tutorial will show you how to deploy your services to your own GCP project 
 * [A `compose.yaml` file in your project](https://docs.docker.com/compose/gettingstarted/)
 * [A Defang Account](/docs/concepts/authentication)
 * [The Defang CLI](/docs/getting-started#install-the-defang-cli)
-* [gcloud CL](https://cloud.google.com/sdk/docs/install)
+* [gcloud CLI](https://cloud.google.com/sdk/docs/install)
 * [GCP Account Credentials](https://cloud.google.com/docs/authentication/set-up-adc-local-dev-environment)
 
 ## Step 1 - Navigate to your project directory


### PR DESCRIPTION
The link was missing an `I` on the word `gcloud CLI`.